### PR TITLE
3 - 67 Fix Queue API to be less memory hungry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(TARGET_TYPE "freertos_idf"
-  CACHE STRING "Type of build: 'linux_glibc', 'freertos_idf'")
+  CACHE STRING "Type of build: 'linux_glib', 'freertos_idf'")
 
 file(TO_CMAKE_PATH "$ENV{IDF_PATH}" ENV_IDF_PATH)
 
@@ -20,12 +20,12 @@ if("${TARGET_TYPE}" STREQUAL "" OR "${TARGET_TYPE}" STREQUAL "freertos_idf")
     add_compile_definitions(configUSE_POSIX_ERRNO=1)
     project(RINA_sensor)
   else()
-    message(FATAL_ERROR " The 'freertos_idf' target needs the IDF_PATH environment variable to be defined ")
+    message(FATAL_ERROR "The 'freertos_idf' target needs the IDF_PATH environment variable to be defined")
   endif()
-elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
+elseif(${TARGET_TYPE} STREQUAL "linux_glib")
   project(RINA_sensor)
 
-  message(" Configuring: POSIX build ")
+  message("Configuring: POSIX build")
 
   include(CTest)
 
@@ -39,38 +39,38 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # Set all include path variables here so as to avoid circular
   # dependencies problem below.
   #
-  set(CdapProto_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/CdapProto/include ")
-  set(configSensor_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/configSensor/include ")
-  set(configRINA_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/configRINA/include ")
-  set(Common_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/Common/include ")
-  set(ARP826_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/ARP826/include ")
-  set(BufferManagement_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/BufferManagement/include ")
-  set(EFCP_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/EFCP/include ")
-  set(IPCP_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/IPCP/include ")
-  set(NetworkInterface_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface/include ")
-  set(NetworkInterface_MQ_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface/mq/include ")
-  set(RINA_API_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/RINA_API/include ")
-  set(Rmt_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/Rmt/include ")
-  set(ShimIPCP_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/ShimIPCP/include ")
-  set(FlowAllocator_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/FlowAllocator/include ")
-  set(Ribd_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/Ribd/include ")
-  set(Enrollment_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components/Enrollment/include ")
+  set(CdapProto_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/CdapProto/include")
+  set(configSensor_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/configSensor/include")
+  set(configRINA_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/configRINA/include")
+  set(Common_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/Common/include")
+  set(ARP826_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/ARP826/include")
+  set(BufferManagement_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/BufferManagement/include")
+  set(EFCP_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/EFCP/include")
+  set(IPCP_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/IPCP/include")
+  set(NetworkInterface_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface/include")
+  set(NetworkInterface_MQ_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface/mq/include")
+  set(RINA_API_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/RINA_API/include")
+  set(Rmt_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/Rmt/include")
+  set(ShimIPCP_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/ShimIPCP/include")
+  set(FlowAllocator_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/FlowAllocator/include")
+  set(Ribd_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/Ribd/include")
+  set(Enrollment_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components/Enrollment/include")
 
-  set(mock_IPCP_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_IPCP/include ")
+  set(mock_IPCP_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_IPCP/include")
   set(mock_NetworkInterface_INCLUDES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/include ")
-  set(mock_FlowAllocator_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_FlowAllocator/include ")
-  set(mock_Ribd_INCLUDES " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_Ribd/include ")
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/include ")
+  set(mock_FlowAllocator_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_FlowAllocator/include")
+  set(mock_Ribd_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_Ribd/include")
 
   #
   # Portability layer, target specific
   #
-  include(" ${CMAKE_CURRENT_SOURCE_DIR}/components/Portability/${TARGET_TYPE}/CMakeLists.txt ")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/components/Portability/${TARGET_TYPE}/CMakeLists.txt")
 
   #
   # Portability layer tests
   #
-  include(" ${CMAKE_CURRENT_SOURCE_DIR}/components/Portability/test/CMakeLists.txt ")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/components/Portability/test/CMakeLists.txt")
 
   #
   # Mock objects
@@ -78,9 +78,9 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # FIXME: THIS IS BORING AND REPETITIVE, MOVE THAT ELSEWHERE!
   #
   set(mock_NetworkInterface_INCLUDES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/include ")
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/include")
   file(GLOB mock_NetworkInterface_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_NetworkInterface/*.c"
   )
   add_library(mock_NetworkInterface STATIC ${mock_NetworkInterface_SOURCES})
   target_include_directories(mock_NetworkInterface PUBLIC
@@ -93,7 +93,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   )
 
   file(GLOB mock_IPCP_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_IPCP/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_IPCP/*.c"
   )
   add_library(mock_IPCP STATIC ${mock_IPCP_SOURCES})
   target_include_directories(mock_IPCP PUBLIC
@@ -103,7 +103,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   )
 
   file(GLOB mock_RIBD_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_Ribd/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_Ribd/*.c"
   )
   add_library(mock_Ribd STATIC ${mock_RIBD_SOURCES})
   target_include_directories(mock_Ribd PUBLIC
@@ -117,7 +117,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   )
 
   file(GLOB mock_FlowAllocator_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_FlowAllocator/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_FlowAllocator/*.c"
   )
   add_library(mock_FlowAllocator STATIC ${mock_FlowAllocator_SOURCES})
   target_include_directories(mock_FlowAllocator PUBLIC
@@ -133,7 +133,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   )
 
   file(GLOB mock_EFCP_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_EFCP/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components_mocks/mock_EFCP/*.c"
   )
   add_library(mock_EFCP STATIC ${mock_EFCP_SOURCES})
   target_include_directories(mock_EFCP PUBLIC
@@ -151,7 +151,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # Component: CDAP
   #
   file(GLOB CdapProto_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/CdapProto/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/CdapProto/*.c"
   )
   add_library(CdapProto STATIC ${CdapProto_SOURCES})
   target_include_directories(CdapProto PUBLIC ${CdapProto_INCLUDES})
@@ -161,7 +161,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # Component: configSensor
   #
   file(GLOB configSensor_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/configSensor/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/configSensor/*.c"
   )
   add_library(configSensor STATIC ${configSensor_SOURCES})
   target_include_directories(configSensor PUBLIC ${configSensor_INCLUDES})
@@ -170,10 +170,10 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   #
   # Component: Common
   #
-  set(Common_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/Common ")
-  set(Common_TEST_DIR " ${Common_DIR}/test ")
+  set(Common_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/Common")
+  set(Common_TEST_DIR "${Common_DIR}/test")
   file(GLOB Common_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/Common/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/Common/*.c"
   )
   add_library(Common STATIC ${Common_SOURCES})
   target_include_directories(Common PUBLIC
@@ -181,15 +181,15 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     ${Portability_INCLUDES}
     ${configSensor_INCLUDES}
   )
-  include(" ${Common_TEST_DIR}/CMakeLists.txt ")
+  include("${Common_TEST_DIR}/CMakeLists.txt")
 
   #
   # Component: BufferManagement
   #
-  set(BufferManagement_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/BufferManagement ")
-  set(BufferManagement_TEST_DIR " ${BufferManagement_DIR}/test ")
+  set(BufferManagement_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/BufferManagement")
+  set(BufferManagement_TEST_DIR "${BufferManagement_DIR}/test")
   file(GLOB BufferManagement_SOURCES
-    " ${BufferManagement_DIR}/*.c "
+    "${BufferManagement_DIR}/*.c"
   )
   add_library(BufferManagement STATIC ${BufferManagement_SOURCES})
   target_include_directories(BufferManagement PUBLIC
@@ -212,16 +212,16 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     IPCP
     portability
   )
-  include(" ${BufferManagement_TEST_DIR}/CMakeLists.txt ")
+  include("${BufferManagement_TEST_DIR}/CMakeLists.txt")
 
   #
   # Component: NetworkInterface
   #
   # FIXME: The 'mq' NetworkInterface is for testing only. We need to
   # figure out how to support multiple type of NetworkInterface.
-  set(NetworkInterface_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface ")
+  set(NetworkInterface_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface")
   file(GLOB NetworkInterface_SOURCES
-    " ${NetworkInterface_DIR}/mq/*.c "
+    "${NetworkInterface_DIR}/mq/*.c"
   )
   add_library(NetworkInterface STATIC ${NetworkInterface_SOURCES})
   target_include_directories(NetworkInterface PUBLIC
@@ -238,13 +238,16 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     ${EFCP_INCLUDES}
     ${Portability_INCLUDES}
   )
-  include(" ${NetworkInterface_DIR}/test/CMakeLists.txt ")
+  target_link_libraries(NetworkInterface PUBLIC
+    Common
+  )
+  include("${NetworkInterface_DIR}/test/CMakeLists.txt")
 
   # Component: ARP826
   #
-  set(ARP826_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/ARP826 ")
-  set(ARP826_TEST_DIR " ${ARP826_DIR}/test ")
-  file(GLOB ARP826_SOURCES " ${ARP826_DIR}/*.c ")
+  set(ARP826_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/ARP826")
+  set(ARP826_TEST_DIR "${ARP826_DIR}/test")
+  file(GLOB ARP826_SOURCES "${ARP826_DIR}/*.c")
   add_library(ARP826 STATIC ${ARP826_SOURCES})
   target_include_directories(ARP826 PUBLIC
     ${configSensor_INCLUDES}
@@ -264,13 +267,13 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     portability
     ShimIPCP
   )
-  include(" ${ARP826_TEST_DIR}/CMakeLists.txt ")
+  include("${ARP826_TEST_DIR}/CMakeLists.txt")
 
   #
   # Component: Rmt
   #
   file(GLOB Rmt_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/Rmt/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/Rmt/*.c"
   )
   add_library(Rmt STATIC ${Rmt_SOURCES})
   target_include_directories(Rmt PUBLIC
@@ -295,7 +298,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # Component: EFCP
   #
   file(GLOB EFCP_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/EFCP/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/EFCP/*.c"
   )
   add_library(EFCP STATIC ${EFCP_SOURCES})
   target_include_directories(EFCP PUBLIC
@@ -318,9 +321,9 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   #
   # Component: ShimIPCP
   #
-  set(ShimIPCP_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/ShimIPCP ")
-  set(ShimIPCP_TESTS_DIR " ${ShimIPCP_DIR}/test ")
-  file(GLOB ShimIPCP_SOURCES " ${ShimIPCP_DIR}/*.c ")
+  set(ShimIPCP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/ShimIPCP")
+  set(ShimIPCP_TESTS_DIR "${ShimIPCP_DIR}/test")
+  file(GLOB ShimIPCP_SOURCES "${ShimIPCP_DIR}/*.c")
   add_library(ShimIPCP STATIC ${ShimIPCP_SOURCES})
   target_include_directories(ShimIPCP PUBLIC
     ${ShimIPCP_INCLUDES}
@@ -345,15 +348,15 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     NetworkInterface
     Rmt
   )
-  include(" ${ShimIPCP_TESTS_DIR}/CMakeLists.txt ")
+  include("${ShimIPCP_TESTS_DIR}/CMakeLists.txt")
 
   #
   # Component: IPCP
   #
-  set(IPCP_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/IPCP ")
-  set(IPCP_TESTS_DIR " ${IPCP_DIR}/test ")
-  set(IPCP_TEST_DIR " ${IPCP_DIR}/test ")
-  file(GLOB IPCP_SOURCES " ${IPCP_DIR}/*.c ")
+  set(IPCP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/IPCP")
+  set(IPCP_TESTS_DIR "${IPCP_DIR}/test")
+  set(IPCP_TEST_DIR "${IPCP_DIR}/test")
+  file(GLOB IPCP_SOURCES "${IPCP_DIR}/*.c")
   add_library(IPCP STATIC ${IPCP_SOURCES})
   target_include_directories(IPCP PUBLIC
     ${configSensor_INCLUDES}
@@ -387,14 +390,14 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     Ribd
     FlowAllocator
   )
-  include(" ${IPCP_TESTS_DIR}/CMakeLists.txt ")
+  include("${IPCP_TESTS_DIR}/CMakeLists.txt")
 
   #
   # Component: Ribd
   #
-  set(Ribd_DIR " ${CMAKE_CURRENT_SOURCE_DIR}/components/Ribd ")
-  set(Ribd_TEST_DIR " ${Ribd_DIR}/test ")
-  file(GLOB Ribd_SOURCES " ${Ribd_DIR}/*.c ")
+  set(Ribd_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/Ribd")
+  set(Ribd_TEST_DIR "${Ribd_DIR}/test")
+  file(GLOB Ribd_SOURCES "${Ribd_DIR}/*.c")
   add_library(Ribd STATIC ${Ribd_SOURCES})
   target_include_directories(Ribd PUBLIC
     ${CdapProto_INCLUDES}
@@ -422,13 +425,13 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
     Rmt
     FlowAllocator
   )
-  include(" ${Ribd_TEST_DIR}/CMakeLists.txt ")
+  include("${Ribd_TEST_DIR}/CMakeLists.txt")
 
   #
   # Component: FlowAllocator
   #
   file(GLOB FlowAllocator_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/FlowAllocator/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/FlowAllocator/*.c"
   )
   add_library(FlowAllocator STATIC ${FlowAllocator_SOURCES})
   target_include_directories(FlowAllocator PUBLIC
@@ -462,7 +465,7 @@ elseif(${TARGET_TYPE} STREQUAL " linux_glib ")
   # Component: Enrollment
   #
   file(GLOB Enrollment_SOURCES
-    " ${CMAKE_CURRENT_SOURCE_DIR}/components/Enrollment/*.c "
+    "${CMAKE_CURRENT_SOURCE_DIR}/components/Enrollment/*.c"
   )
   add_library(Enrollment STATIC ${Enrollment_SOURCES})
   target_include_directories(Enrollment PUBLIC

--- a/components/EFCP/CMakeLists.txt
+++ b/components/EFCP/CMakeLists.txt
@@ -1,3 +1,16 @@
 idf_component_register(SRCS "connection.c" "delim.c" "EFCP.c" "dtp.c" "delim.c"
     INCLUDE_DIRS "include"
     REQUIRES IPCP Rmt FlowAllocator Portability)
+
+if("$ENV{USE_MOCKS}" STREQUAL "true")
+  target_include_directories(${COMPONENT_LIB} BEFORE PUBLIC
+    "${CMAKE_SOURCE_DIR}/../components_mocks/mock_FlowAllocator/include"
+  )
+
+  # Per https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#advanced-workaround-undefined-symbols
+  #
+  # I tried this randomly to fix a link error and it kind of magically
+  # worked so I'm leaving that here. I don't claim to understand the
+  # problem.
+  target_link_libraries(${COMPONENT_LIB} INTERFACE "-u mock_FlowAllocator_xFlowAllocatorDuPost")
+endif()

--- a/components/EFCP/dtp.c
+++ b/components/EFCP/dtp.c
@@ -30,11 +30,11 @@ dtpSv_t *pxDtpStateVectorInit(void)
         pxDtpSv->stats.rx_pdus = 0;               // ok
         pxDtpSv->stats.rx_bytes = 0;
         // ok
-        pxDtpSv->xRexmsnCtrl = pdFALSE;      // ok
-        pxDtpSv->xRateBased = pdFALSE;       // ok
-        pxDtpSv->xWindowBased = pdFALSE;     // ok
-        pxDtpSv->xDrfRequired = pdTRUE;      // ok
-        pxDtpSv->xRateFulfiled = pdFALSE;    // ok
+        pxDtpSv->xRexmsnCtrl = false;      // ok
+        pxDtpSv->xRateBased = false;       // ok
+        pxDtpSv->xWindowBased = false;     // ok
+        pxDtpSv->xDrfRequired = true;      // ok
+        pxDtpSv->xRateFulfiled = false;    // ok
         pxDtpSv->xMaxFlowPduSize = UINT_MAX; // ok
         pxDtpSv->xMaxFlowSduSize = UINT_MAX; // ok
         //.MPL                  = 1000,
@@ -42,8 +42,8 @@ dtpSv_t *pxDtpStateVectorInit(void)
         //.A                    = 0,
         //.tr                   = 0,
         pxDtpSv->xRcvLeftWindowEdge = 0;  // ok
-        pxDtpSv->xWindowClosed = pdFALSE; // ok
-        pxDtpSv->xDrfFlag = pdTRUE;       // ok
+        pxDtpSv->xWindowClosed = false; // ok
+        pxDtpSv->xDrfFlag = true;       // ok
 
         return pxDtpSv;
 }

--- a/components/EFCP/include/EFCP.h
+++ b/components/EFCP/include/EFCP.h
@@ -23,9 +23,9 @@ bool_t xEfcpContainerWrite(struct efcpContainer_t *pxEfcpContainer, cepId_t xCep
 
 bool_t xEfcpConnectionDestroy(struct efcpContainer_t * pxContainer, cepId_t xId);
 
-BaseType_t xEfcpConnectionUpdate(struct efcpContainer_t *pxContainer,
-                                 cepId_t from,
-                                 cepId_t to);
+bool_t xEfcpConnectionUpdate(struct efcpContainer_t *pxContainer,
+                             cepId_t from,
+                             cepId_t to);
 
 cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                               address_t xSrcAddr,
@@ -37,9 +37,9 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                               dtpConfig_t *pxDtpCfg,
                               struct dtcpConfig_t *pxDtcpCfg);
 
-BaseType_t xEfcpConnectionModify(struct efcpContainer_t *pxContainer,
-                                 cepId_t xCepId,
-                                 address_t xSrc,
-                                 address_t xDst);
+bool_t xEfcpConnectionModify(struct efcpContainer_t *pxContainer,
+                             cepId_t xCepId,
+                             address_t xSrc,
+                             address_t xDst);
 
 #endif /* EFCP_H__*/

--- a/components/Enrollment/SerdesMsg.c
+++ b/components/Enrollment/SerdesMsg.c
@@ -167,7 +167,7 @@ static aDataMsg_t *prvSerdesMsgDecodeAData(rina_messages_a_data_t message)
 {
     aDataMsg_t *pxMessage;
 
-    pxMessage = pvPortMalloc(sizeof(*pxMessage));
+    pxMessage = pvRsMemAlloc(sizeof(*pxMessage));
 
     if (message.has_destAddress)
     {
@@ -180,8 +180,8 @@ static aDataMsg_t *prvSerdesMsgDecodeAData(rina_messages_a_data_t message)
     }
     if (message.has_cdapMessage)
     {
-        serObjectValue_t *pxMsgCdap = pvPortMalloc(sizeof(*pxMsgCdap));
-        void *pvSerBuf = pvPortMalloc(message.cdapMessage.size);
+        serObjectValue_t *pxMsgCdap = pvRsMemAlloc(sizeof(*pxMsgCdap));
+        void *pvSerBuf = pvRsMemAlloc(message.cdapMessage.size);
 
         pxMessage->pxMsgCdap = pxMsgCdap;
         pxMessage->pxMsgCdap->pvSerBuffer = pvSerBuf;
@@ -197,7 +197,7 @@ static aDataMsg_t *prvSerdesMsgDecodeAData(rina_messages_a_data_t message)
 aDataMsg_t *pxSerdesMsgDecodeAData(uint8_t *pucBuffer, size_t xMessageLength)
 {
 
-    BaseType_t status;
+    bool_t status;
 
     /*Allocate space for the decode message data*/
     rina_messages_a_data_t message = rina_messages_a_data_t_init_zero;
@@ -455,8 +455,7 @@ void prvPrintDecodeFlow(rina_messages_Flow message)
 
 flow_t *pxSerdesMsgDecodeFlow(uint8_t *pucBuffer, size_t xMessageLength)
 {
-
-    BaseType_t status;
+    bool_t status;
 
     /*Allocate space for the decode message data*/
     rina_messages_Flow message = rina_messages_Flow_init_zero;

--- a/components/FlowAllocator/include/FlowAllocator.h
+++ b/components/FlowAllocator/include/FlowAllocator.h
@@ -118,7 +118,7 @@ typedef struct xFLOW_MESSAGE
 typedef struct xREQUEST_HANDLER_ROW
 {
     flowAllocatorInstance_t *pxFAI;
-    BaseType_t xValid;
+    bool_t xValid;
 
 } FlowRequestRow_t;
 

--- a/components/FlowAllocator/include/FlowAllocator_api.h
+++ b/components/FlowAllocator/include/FlowAllocator_api.h
@@ -3,9 +3,8 @@
 
 #include "FlowAllocator.h"
 
-void vFlowAllocatorFlowRequest(
-    portId_t xAppPortId,
-    flowAllocateHandle_t *pxFlowRequest);
+void vFlowAllocatorFlowRequest(portId_t xAppPortId,
+                               flowAllocateHandle_t *pxFlowRequest);
 
 bool_t xFlowAllocatorHandleCreateR(serObjectValue_t *pxSerObjValue, int result);
 

--- a/components/IPCP/IPCP.c
+++ b/components/IPCP/IPCP.c
@@ -1,3 +1,4 @@
+#include "IPCP_events.h"
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
@@ -236,7 +237,7 @@ static void *prvIPCPTask(void *pvParameters)
         /* Wait until there is something to do. If the following call exits
          * due to a time out rather than a message being received, set a
          * 'NoEvent' value. */
-        if (xRsQueueReceive(xNetworkEventQueue, (void *)&xReceivedEvent, xSleepTimeUS) == false)
+        if (xRsQueueReceive(xNetworkEventQueue, (void *)&xReceivedEvent, sizeof(RINAStackEvent_t), xSleepTimeUS) == false)
             xReceivedEvent.eEventType = eNoEvent;
 
         switch (xReceivedEvent.eEventType)
@@ -510,7 +511,7 @@ bool_t xSendEventStructToIPCPTask(const RINAStackEvent_t *pxEvent, useconds_t xT
             else
                 xCalculatedTimeOutUS = xTimeOutUS;
 
-            xReturn = xRsQueueSendToBack(xNetworkEventQueue, pxEvent, xCalculatedTimeOutUS);
+            xReturn = xRsQueueSendToBack(xNetworkEventQueue, pxEvent, sizeof(RINAStackEvent_t), xCalculatedTimeOutUS);
 
             if (!xReturn)
                 LOGE(TAG_IPCPMANAGER, "Failed to add message to IPCP queue (errno: %d)", errno);

--- a/components/IPCP/IPCP.c
+++ b/components/IPCP/IPCP.c
@@ -31,8 +31,7 @@
 #include "portability/rsqueue.h"
 #include "portability/rstime.h"
 #include "rina_buffers.h"
-#include "rina_common.h"
-#include "RINA_API.h"
+#include "rina_common_port.h"
 
 MACAddress_t xlocalMACAddress = {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
@@ -111,7 +110,7 @@ static void *prvIPCPTask(void *pvParameters);
 
 static bool_t prvIPCPTimerCheck(IPCPTimer_t *pxTimer);
 
-void vIpcpSetFATimerExpiredState(BaseType_t xExpiredState);
+void vIpcpSetFATimerExpiredState(bool_t xExpiredState);
 
 /*
  * Utility functions for the light weight IP timers.
@@ -296,7 +295,7 @@ static void *prvIPCPTask(void *pvParameters)
             break;
         case eFATimerEvent:
             LOGI(TAG_IPCPMANAGER, "Setting FA timer to expired");
-            vIpcpSetFATimerExpiredState(pdTRUE);
+            vIpcpSetFATimerExpiredState(true);
 
             break;
         case eFlowDeallocateEvent:
@@ -308,6 +307,7 @@ static void *prvIPCPTask(void *pvParameters)
 
         case eFlowBindEvent:
 
+#if 0
             pxFlowAllocateRequest = ((flowAllocateHandle_t *)xReceivedEvent.pvData);
 
             (void)xNormalFlowPrebind(pxIpcpData, pxFlowAllocateRequest);
@@ -315,7 +315,7 @@ static void *prvIPCPTask(void *pvParameters)
             pxFlowAllocateRequest->xEventBits |= (EventBits_t)eFLOW_BOUND;
 
             vRINA_WeakUpUser(pxFlowAllocateRequest);
-
+#endif
             break;
 
         case eSendMgmtEvent:
@@ -831,17 +831,17 @@ static bool_t prvIPCPTimerCheck(IPCPTimer_t *pxTimer)
  *
  * @param[in] xExpiredState: pdTRUE - set as expired; pdFALSE - set as non-expired.
  */
-void vIpcpSetFATimerExpiredState(BaseType_t xExpiredState)
+void vIpcpSetFATimerExpiredState(bool_t xExpiredState)
 {
-    xFATimer.bActive = pdTRUE_UNSIGNED;
+    xFATimer.bActive = true;
 
-    if (xExpiredState != pdFALSE)
+    if (xExpiredState != false)
     {
-        xFATimer.bExpired = pdTRUE_UNSIGNED;
+        xFATimer.bExpired = true;
     }
     else
     {
-        xFATimer.bExpired = pdFALSE_UNSIGNED;
+        xFATimer.bExpired = false;
     }
 }
 

--- a/components/IPCP/include/rina_common.h
+++ b/components/IPCP/include/rina_common.h
@@ -82,18 +82,6 @@ typedef struct xDIF_CONFIG
 #define FreeRTOS_ntohl(x) FreeRTOS_htonl(x)
 #define SOCKET_EVENT_BIT_COUNT 8
 
-enum eFLOW_EVENT
-{
-        eFLOW_RECEIVE = 0x0001,
-        eFLOW_SEND = 0x0002,
-        eFLOW_ACCEPT = 0x0004,
-        eFLOW_CONNECT = 0x0008,
-        eFLOW_BOUND = 0x0010,
-        eFLOW_CLOSED = 0x0020,
-        eSELECT_ALL = 0x000F,
-
-};
-
 // name_t *xRinaNameCreate(void);
 
 // BaseType_t xRinaNameFromString(const string_t pcString, name_t *xName);

--- a/components/IPCP/include/rina_common_port.h
+++ b/components/IPCP/include/rina_common_port.h
@@ -222,5 +222,16 @@ typedef struct xIPCP_TIMER
     useconds_t ulReloadTimeUS;    /**< The value of reload time. */
 } IPCPTimer_t;
 
+enum eFLOW_EVENT
+{
+        eFLOW_RECEIVE = 0x0001,
+        eFLOW_SEND = 0x0002,
+        eFLOW_ACCEPT = 0x0004,
+        eFLOW_CONNECT = 0x0008,
+        eFLOW_BOUND = 0x0010,
+        eFLOW_CLOSED = 0x0020,
+        eSELECT_ALL = 0x000F,
+};
+
 #endif // _COMPONENTS_IPCP_INCLUDE_COMMON_PORT_H#
 

--- a/components/IPCP/normalIPCP.c
+++ b/components/IPCP/normalIPCP.c
@@ -149,10 +149,10 @@ static struct normalFlow_t *prvNormalFindFlow(struct ipcpInstanceData_t *pxData,
                 pxFlow = (struct normalFlow_t *)pRsListGetListItemOwner(pxListItem);
 
                 if (pxFlow == NULL)
-                        return pdFALSE;
+                        return false;
 
                 if (!pxFlow)
-                        return pdFALSE;
+                        return false;
 
                 if (pxFlow && pxFlow->xPortId == xPortId)
                 {
@@ -168,9 +168,9 @@ static struct normalFlow_t *prvNormalFindFlow(struct ipcpInstanceData_t *pxData,
         return NULL;
 }
 
-BaseType_t xNormalDuWrite(struct ipcpInstanceData_t *pxData,
-                          portId_t xAppPortId,
-                          NetworkBufferDescriptor_t *pxNetworkBuffer)
+bool_t xNormalDuWrite(struct ipcpInstanceData_t *pxData,
+                      portId_t xAppPortId,
+                      NetworkBufferDescriptor_t *pxNetworkBuffer)
 {
         LOGI(TAG_IPCPNORMAL, "Writing Data into the IPCP Normal");
         struct du_t *pxDu;
@@ -678,7 +678,7 @@ bool_t xNormalFlowAllocationRequest(ipcpInstance_t *pxInstanceFrom, ipcpInstance
         return false;
 }
 
-BaseType_t xNormalAppFlowAllocationRequestHandle(ipcpInstance_t)
+bool_t xNormalAppFlowAllocationRequestHandle(ipcpInstance_t)
 
 
 
@@ -698,7 +698,7 @@ xNormalConnectionCreateRequest(pxNormalInstance->pxData, xPortId,
                                pxDtcpCfg);
 
 #endif
-BaseType_t xNormalUpdateFlowStatus(portId_t xPortId, eNormalFlowState_t eNewFlowstate)
+bool_t xNormalUpdateFlowStatus(portId_t xPortId, eNormalFlowState_t eNewFlowstate)
 {
         struct normalFlow_t *pxFlow = NULL;
 
@@ -706,12 +706,12 @@ BaseType_t xNormalUpdateFlowStatus(portId_t xPortId, eNormalFlowState_t eNewFlow
         if (!pxFlow)
         {
                 LOGE(TAG_IPCPNORMAL, "Flow not found");
-                return pdFALSE;
+                return false;
         }
         pxFlow->eState = eNewFlowstate;
         LOGI(TAG_IPCPNORMAL, "Flow state updated");
 
-        return pdTRUE;
+        return true;
 }
 
 bool_t xNormalIsFlowAllocated(portId_t xPortId)
@@ -785,7 +785,7 @@ bool_t xNormalConnectionUpdate(portId_t xAppPortId, cepId_t xSrcCepId, cepId_t x
         return true;
 }
 
-static BaseType_t prvRemoveCepIdFromFlow(struct normalFlow_t *pxFlow,
+static bool_t prvRemoveCepIdFromFlow(struct normalFlow_t *pxFlow,
                                          cepId_t xCepId)
 {
 #if 0
@@ -849,7 +849,7 @@ static BaseType_t prvRemoveCepIdFromFlow(struct normalFlow_t *pxFlow,
         }
         return -1;
 #endif
-        return pdFALSE;
+        return false;
 }
 
 static struct normalFlow_t *prvFindFlowCepid(cepId_t xCepId)
@@ -861,31 +861,27 @@ static struct normalFlow_t *prvFindFlowCepid(cepId_t xCepId)
 
         // shimFlow_t *pxFlowNext;
 
-        ListItem_t *pxListItem;
-        ListItem_t const *pxListEnd;
+        RsListItem_t *pxListItem;
+        RsListItem_t const *pxListEnd;
 
-        if (listLIST_IS_EMPTY(&(pxIpcpData->xFlowsList)) == pdTRUE)
+        if (unRsListCurrentListLength(&(pxIpcpData->xFlowsList)) == 0)
         {
                 LOGE(TAG_IPCPNORMAL, "Flow list is empty");
                 return NULL;
         }
 
-        pxFlow = pvPortMalloc(sizeof(*pxFlow));
+        pxFlow = pvRsMemAlloc(sizeof(*pxFlow));
 
         /* Find a way to iterate in the list and compare the addesss*/
-        pxListEnd = listGET_END_MARKER(&(pxIpcpData->xFlowsList));
-        pxListItem = listGET_HEAD_ENTRY(&(pxIpcpData->xFlowsList));
+        pxListEnd = pRsListGetEndMarker(&(pxIpcpData->xFlowsList));
+        pxListItem = pRsListGetHeadEntry(&(pxIpcpData->xFlowsList));
 
         while (pxListItem != pxListEnd)
         {
-
-                pxFlow = (struct normalFlow_t *)listGET_LIST_ITEM_OWNER(pxListItem);
-
-                if (pxFlow == NULL)
-                        return pdFALSE;
+                pxFlow = (struct normalFlow_t *)pRsListGetListItemOwner(pxListItem);
 
                 if (!pxFlow)
-                        return pdFALSE;
+                        return false;
 
                 if (pxFlow && pxFlow->xActive == xCepId)
                 {
@@ -894,14 +890,14 @@ static struct normalFlow_t *prvFindFlowCepid(cepId_t xCepId)
                         return pxFlow;
                 }
 
-                pxListItem = listGET_NEXT(pxListItem);
+                pxListItem = pRsListGetNext(pxListItem);
         }
 
         LOGI(TAG_IPCPNORMAL, "Flow not founded");
         return NULL;
 }
 
-BaseType_t xNormalConnectionDestroy(cepId_t xSrcCepId)
+bool_t xNormalConnectionDestroy(cepId_t xSrcCepId)
 {
         struct normalFlow_t *pxFlow;
 
@@ -913,14 +909,14 @@ BaseType_t xNormalConnectionDestroy(cepId_t xSrcCepId)
         {
                 // CRITICAL
                 LOGE(TAG_EFCP, "Could not destroy EFCP instance: %d", xSrcCepId);
-                return pdFALSE;
+                return false;
         }
         pxFlow = prvFindFlowCepid(xSrcCepId);
         if (!pxFlow)
         {
                 // CRITICAL
                 LOGE(TAG_IPCPNORMAL, "Could not retrieve flow by cep_id :%d", xSrcCepId);
-                return pdFALSE;
+                return false;
         }
         /*if (remove_cep_id_from_flow(flow, src_cep_id))
                 LOG_ERR("Could not remove cep_id: %d", src_cep_id);
@@ -932,5 +928,5 @@ BaseType_t xNormalConnectionDestroy(cepId_t xSrcCepId)
         }*/
         // CRITICAL
 
-        return pdTRUE;
+        return true;
 }

--- a/components/Portability/include/portability/rsqueue.h
+++ b/components/Portability/include/portability/rsqueue.h
@@ -9,15 +9,20 @@
 /* Minimal queue API based on what is required in the IPCP. */
 
 RsQueue_t *pxRsQueueCreate(const char *sQueueName,
-                          size_t uxQueueLength, size_t uxItemSize);
+                           const size_t uxQueueLength,
+                           const size_t uxItemSize);
 
 void vRsQueueDelete(RsQueue_t *pQueue);
 
 bool_t xRsQueueSendToBack(RsQueue_t *pxQueue,
-                         const void *pvItemToQueue, useconds_t xTimeOutUS);
+                          const void *pvItemToQueue,
+                          const size_t unItemSize,
+                          const useconds_t xTimeOutUS);
 
 bool_t xRsQueueReceive(RsQueue_t *pxQueue,
-                      void *pvBuffer, useconds_t xTimeOutUS);
+                       void *pvBuffer,
+                       const size_t unBufferSize,
+                       const useconds_t xTimeOutUS);
 
 #endif // _COMMON_PORTABILITY_RSQUEUE_H
 

--- a/components/Portability/posix/include/posix_rsqueue.h
+++ b/components/Portability/posix/include/posix_rsqueue.h
@@ -4,6 +4,7 @@
 #include "portability/posix/mqueue.h"
 
 #ifndef PORT_HAS_RSQUEUE_T
+
 typedef struct xRSQUEUE_T {
     mqd_t xQueue;
 
@@ -12,6 +13,7 @@ typedef struct xRSQUEUE_T {
 
     char *sQueueName;
 } RsQueue_t;
+
 #define PORT_HAS_RSQUEUE_T
 #endif // PORT_HAS_RSQUEUE_T
 

--- a/components/Portability/posix/posix_rsqueue.c
+++ b/components/Portability/posix/posix_rsqueue.c
@@ -9,10 +9,12 @@
 
 /**
  * There are some specific rules you must follow for sQueueName. See
- * the "mq_overview" manual page for the rules.
+ * the "mq_overview" manual page for the rules. Don't prefix the queue
+ * name with / as this implementation handles this.
  */
 RsQueue_t *pxRsQueueCreate(const char *sQueueName,
-                           size_t uxQueueLength, size_t uxItemSize)
+                           const size_t uxQueueLength,
+                           const size_t uxItemSize)
 {
     RsQueue_t *pQueue;
     mqd_t xQueue;
@@ -73,7 +75,10 @@ void vRsQueueDelete(RsQueue_t *pQueue)
  * FreeRTOS xQueueSendToBack returns immediately if the timeout is set
  * to 0, so this functions tries to imitate this semantic.
  */
-bool_t xRsQueueSendToBack(RsQueue_t *pQueue, const void *pvItemToQueue, useconds_t xTimeOutUS)
+bool_t xRsQueueSendToBack(RsQueue_t *pQueue,
+                          const void *pvItemToQueue,
+                          const size_t unItemSize,
+                          const useconds_t xTimeOutUS)
 {
     struct timespec ts;
     struct mq_attr attr;
@@ -91,9 +96,7 @@ bool_t xRsQueueSendToBack(RsQueue_t *pQueue, const void *pvItemToQueue, useconds
             }
 
             /* Queue not full? mq_send is not supposed to block here. */
-            /* FIXME: DON'T SEND pQueue->uxItemSize BYTES. THIS IS
-               WASTEFUL. */
-            if (mq_send(pQueue->xQueue, pvItemToQueue, pQueue->uxItemSize, 0) != 0) {
+            if (mq_send(pQueue->xQueue, pvItemToQueue, unItemSize, 0) != 0) {
                 LOGE(TAG, "mq_send failed (errno: %d)", errno);
                 return false;
             }
@@ -108,25 +111,25 @@ bool_t xRsQueueSendToBack(RsQueue_t *pQueue, const void *pvItemToQueue, useconds
         if (!rstime_waitusec(&ts, xTimeOutUS))
             return false;
 
-        if (mq_timedsend(pQueue->xQueue, pvItemToQueue, pQueue->uxItemSize, 0, &ts) != 0) {
+        if (mq_timedsend(pQueue->xQueue, pvItemToQueue, unItemSize, 0, &ts) != 0) {
             LOGE(TAG, "mq_timedsend failed (errno: %d)", errno);
             return false;
         }
     }
 
-    LOGD(TAG, "Sent %u byte(s) on %s", pQueue->uxItemSize, pQueue->sQueueName);
+    LOGD(TAG, "Sent %zu byte(s) on %s", pQueue->uxItemSize, pQueue->sQueueName);
 
     return true;
 }
 
-bool_t xRsQueueReceive(RsQueue_t *pQueue, void *pvBuffer, useconds_t xTimeOutUS)
+bool_t xRsQueueReceive(RsQueue_t *pQueue, void *pvBuffer, const size_t unBufferSz, useconds_t xTimeOutUS)
 {
     struct timespec ts;
 
     if (!rstime_waitusec(&ts, xTimeOutUS))
         return false;
 
-    if (mq_timedreceive(pQueue->xQueue, pvBuffer, pQueue->uxItemSize, 0, &ts) < 0)
+    if (mq_timedreceive(pQueue->xQueue, pvBuffer, unBufferSz, 0, &ts) < 0)
         return false;
 
     return true;

--- a/components/Portability/test/test_queues.c
+++ b/components/Portability/test/test_queues.c
@@ -3,6 +3,7 @@
 
 #include "portability/port.h"
 
+#include "portability/rsqueue.h"
 #include "unity.h"
 #include "unity_fixups.h"
 
@@ -26,19 +27,44 @@ RS_TEST_CASE(AddRead, "[queues]")
     RsQueue_t *q;
     uint32_t i1 = 1, i2 = 2;
     uint32_t j1, j2;
-    struct timespec ts;
 
     RS_TEST_CASE_BEGIN(test_queues);
 
     TEST_ASSERT((q = pxRsQueueCreate("testAddRead", 2, sizeof(uint32_t))) != NULL);
 
-    TEST_ASSERT(xRsQueueSendToBack(q, &i1, 1000));
-    TEST_ASSERT(xRsQueueSendToBack(q, &i2, 1000));
+    /* Tests that we can send simple integers to the queue. */
+    TEST_ASSERT(xRsQueueSendToBack(q, &i1, sizeof(i1), 1000));
+    TEST_ASSERT(xRsQueueSendToBack(q, &i2, sizeof(i2), 1000));
 
-    TEST_ASSERT(xRsQueueReceive(q, &j1, 1000));
-    TEST_ASSERT(xRsQueueReceive(q, &j2, 1000));
+    /* Tests that we can read those same integers. */
+    TEST_ASSERT(xRsQueueReceive(q, &j1, sizeof(j1), 1000));
+    TEST_ASSERT(xRsQueueReceive(q, &j2, sizeof(j2), 1000));
     TEST_ASSERT(j1 == i1);
     TEST_ASSERT(j2 == i2);
+
+    vRsQueueDelete(q);
+
+    RS_TEST_CASE_END(test_queues);
+}
+
+RS_TEST_CASE(SizeErrors, "[queues]")
+{
+    RsQueue_t *q;
+    uint32_t i1 = 1, i2 = 2;
+    uint32_t j1;
+
+    RS_TEST_CASE_BEGIN(test_queues);
+
+    TEST_ASSERT((q = pxRsQueueCreate("testSizeErrors", 2, sizeof(uint32_t))) != NULL);
+
+    /* Too much data sent, should fail. */
+    TEST_ASSERT(!xRsQueueSendToBack(q, &i1, sizeof(i1) + 5, 1000));
+
+    /* Send just an interger */
+    TEST_ASSERT(xRsQueueSendToBack(q, &j1, sizeof(j1), 1000));
+
+    /* Not enough space in target buffer, should fail */
+    TEST_ASSERT(!xRsQueueReceive(q, &j1, sizeof(j1) - 1, 1000));
 
     vRsQueueDelete(q);
 
@@ -51,6 +77,7 @@ int main()
     UNITY_BEGIN();
     RS_RUN_TEST(CreateDestroy);
     RS_RUN_TEST(AddRead);
+    RS_RUN_TEST(SizeErrors);
     return UNITY_END();
 }
 #endif

--- a/components/RINA_API/include/RINA_API_flows.h
+++ b/components/RINA_API/include/RINA_API_flows.h
@@ -14,10 +14,12 @@ typedef struct xFLOW_ALLOCATE_HANDLE
 #ifdef ESP_PLATFORM
     EventBits_t xEventBits;         /*Keep Tract of events*/
     EventGroupHandle_t xEventGroup; /*Event Group for this flow allocate request*/
-    TickType_t xReceiveBlockTime;   /**< if recv[to] is called while no data is available, wait this amount of time. Unit in clock-ticks */
-    TickType_t xSendBlockTime;
-    uint16_t usTimeout; /**< Time (in ticks) after which this socket needs attention */
 #endif
+
+    useconds_t xSendBlockTime;
+
+    useconds_t xReceiveBlockTime;   /**< if recv[to] is called while no data is available, wait this amount of time. Unit in microseconds */
+    useconds_t usTimeout; /**< Time (in microseconds) after which this socket needs attention */
 
     portId_t xPortId; /*Should be change by the TASK*/
     name_t *pxLocal;
@@ -25,6 +27,15 @@ typedef struct xFLOW_ALLOCATE_HANDLE
     name_t *pxDifName;
     struct flowSpec_t *pxFspec;
     RsList_t xListWaitingPackets;
+
+    /* Condition variable. */
+    pthread_cond_t xEventCond;
+
+    /* */
+    long nEventBits;
+
+    /* Mutex for nEventBits. */
+    pthread_mutex_t xEventMutex;
 
 } flowAllocateHandle_t;
 

--- a/components/Ribd/Ribd.c
+++ b/components/Ribd/Ribd.c
@@ -864,7 +864,7 @@ void prvRibdHandledAData(serObjectValue_t *pxObjValue)
     if (pxDecodeCdap->eOpCode > MAX_CDAP_OPCODE)
     {
         LOGE(TAG_RIB, "Invalid opcode %s", opcodeNamesTable[pxDecodeCdap->eOpCode]);
-        vPortFree(pxDecodeCdap);
+        vRsMemFree(pxDecodeCdap);
     }
 
     LOGI(TAG_RIB, "Handling CDAP Message: %s", opcodeNamesTable[pxDecodeCdap->eOpCode]);

--- a/components/Ribd/include/Rib.h
+++ b/components/Ribd/include/Rib.h
@@ -55,7 +55,7 @@ struct ribObjOps_t
     bool_t (*create)(struct ribObject_t *, serObjectValue_t *pxObjValue, string_t remote_process_name,
                          string_t local_process_name, int invokeId, portId_t xN1Port);
 
-    BaseType_t (*delete)(struct ribObject_t *pxRibObject, int invoke_id);
+    bool_t (*delete)(struct ribObject_t *pxRibObject, int invoke_id);
 };
 
 struct ribObject_t

--- a/components/Ribd/test/CMakeLists.txt
+++ b/components/Ribd/test/CMakeLists.txt
@@ -13,8 +13,6 @@ else()
     CdapProto
     Rmt
     BufferManagement
-    mock_IPCP
-    IPCP
     EFCP
     FlowAllocator
     unity

--- a/components/ShimIPCP/ShimIPCP.c
+++ b/components/ShimIPCP/ShimIPCP.c
@@ -598,12 +598,14 @@ static shimFlow_t *prvShimFindFlowByPortId(struct ipcpInstanceData_t *pxData, po
 
 	pxFlow = pvRsMemAlloc(sizeof(*pxFlow));
 
+#if 0
 	if (!RsListIsInitilised(&pxData->xFlowsList))
 	{
 		LOGE(TAG_SHIM, "Flow list is not initilized");
 		return NULL;
 	}
-	if (!RsListIsEmpty(&pxData->xFlowsList))
+#endif
+	if (!unRsListCurrentListLength(&pxData->xFlowsList))
 	{
 		LOGE(TAG_SHIM, "Flow list is empty");
 		return NULL;

--- a/components/ShimIPCP/test/CMakeLists.txt
+++ b/components/ShimIPCP/test/CMakeLists.txt
@@ -25,9 +25,7 @@ else()
     rt
 
     mock_NetworkInterface
-    mock_EFCP
     mock_FlowAllocator
     mock_IPCP
-    mock_Ribd
   )
 endif()

--- a/components_mocks/mock_FlowAllocator/CMakeLists.txt
+++ b/components_mocks/mock_FlowAllocator/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
   SRCS "flowAllocator.c"
   INCLUDE_DIRS "include"
-  REQUIRES Portability Common IPCP)
+  REQUIRES Portability Common IPCP mock_FlowAllocator)

--- a/components_mocks/mock_FlowAllocator/flowAllocator.c
+++ b/components_mocks/mock_FlowAllocator/flowAllocator.c
@@ -27,3 +27,31 @@ bool_t xFlowAllocatorHandleCreateR(serObjectValue_t *pxSerObjValue, int result)
     return true;
 }
 
+#ifdef ESP_PLATFORM
+bool_t mock_FlowAllocator_xFlowAllocatorDuPost(portId_t xAppPortId, struct du_t *pxDu)
+#else
+bool_t xFlowAllocatorDuPost(portId_t xAppPortId, struct du_t *pxDu)
+#endif
+{
+    return true;
+}
+
+#ifdef ESP_PLATFORM
+bool_t mock_FlowAllocator_xFlowAllocatorHandleDelete(struct ribObject_t *pxRibObject, int invoke_id)
+#else
+bool_t xFlowAllocatorHandleDelete(struct ribObject_t *pxRibObject, int invoke_id)
+#endif
+{
+    return true;
+}
+
+#ifdef ESP_PLATFORM
+flowAllocateHandle_t *mock_FlowAllocator_pxFAFindFlowHandle(portId_t xPortId)
+#else
+flowAllocateHandle_t *pxFAFindFlowHandle(portId_t xPortId)
+#endif
+{
+    return NULL;
+}
+
+

--- a/components_mocks/mock_FlowAllocator/include/FlowAllocator_api.h
+++ b/components_mocks/mock_FlowAllocator/include/FlowAllocator_api.h
@@ -9,23 +9,35 @@
 
 #define vFlowAllocatorFlowRequest   mock_FlowAllocator_vFlowAllocatorFlowRequest
 #define xFlowAllocatorHandleCreateR mock_FlowAllocator_xFlowAllocatorHandleCreateR
+#define pxFAFindFlowHandle          mock_FlowAllocator_pxFAFindFlowHandle
+#define xFlowAllocatorDuPost        mock_FlowAllocator_xFlowAllocatorDuPost
+#define xFlowAllocatorHandleDelete  mock_FlowAllocator_xFlowAllocatorHandleDelete
 
-void mock_FlowAllocator_vFlowAllocatorFlowRequest(struct efcpContainer_t *pxEfcpc,
-                                                  portId_t xPortId,
-                                                  flowAllocateHandle_t *pxFlowRequest,
-                                                  struct ipcpNormalData_t *pxIpcpData);
+void mock_FlowAllocator_vFlowAllocatorFlowRequest(portId_t xAppPortId,
+                                                  flowAllocateHandle_t *pxFlowRequest);
 
 bool_t mock_FlowAllocator_xFlowAllocatorHandleCreateR(serObjectValue_t *pxSerObjValue,
                                                       int result);
 
+flowAllocateHandle_t *mock_FlowAllocator_pxFAFindFlowHandle(portId_t xPortId);
+
+bool_t mock_FlowAllocator_xFlowAllocatorDuPost(portId_t xAppPortId, struct du_t *pxDu);
+
+bool_t mock_FlowAllocator_xFlowAllocatorHandleDelete(struct ribObject_t *pxRibObject,
+                                                     int invoke_id);
+
 #else
 
-void vFlowAllocatorFlowRequest(struct efcpContainer_t *pxEfcpc,
-                               portId_t xPortId,
-                               flowAllocateHandle_t *pxFlowRequest,
-                               struct ipcpNormalData_t *pxIpcpData);
+void vFlowAllocatorFlowRequest(portId_t xPortId,
+                               flowAllocateHandle_t *pxFlowRequest);
 
 bool_t xFlowAllocatorHandleCreateR(serObjectValue_t *pxSerObjValue, int result);
+
+flowAllocateHandle_t *pxFAFindFlowHandle(portId_t xPortId);
+
+bool_t xFlowAllocatorDuPost(portId_t xAppPortId, struct du_t *pxDu);
+
+bool_t xFlowAllocatorHandleDelete(struct ribObject_t *pxRibObject, int invoke_id);
 
 #endif
 

--- a/components_mocks/mock_Ribd/include/Ribd_api.h
+++ b/components_mocks/mock_Ribd/include/Ribd_api.h
@@ -8,9 +8,8 @@
 bool_t xRibdConnectToIpcp(struct ipcpNormalData_t *pxIpcpData, name_t *pxSource, name_t *pxDestInfo, portId_t xN1flowPortId, authPolicy_t *pxAuth);
 bool_t xRibdDisconnectToIpcp(portId_t xN1flowPortId);
 bool_t xRibdProcessLayerManagementPDU(struct ipcpNormalData_t *pxData, portId_t xN1flowPortId, struct du_t *pxDu);
-bool_t xRibdSendRequest(struct ipcpNormalData_t *pxIpcpData, string_t pcObjClass, string_t pcObjName, long objInst,
+bool_t xRibdSendRequest(string_t pcObjClass, string_t pcObjName, long objInst,
                         opCode_t eOpCode, portId_t xN1flowPortId, serObjectValue_t *pxObjVal);
-
 bool_t xRibdSendResponse(string_t pcObjClass, string_t pcObjName, long objInst,
                          int result, string_t pcResultReason,
                          opCode_t eOpCode, int invokeId, portId_t xN1Port,


### PR DESCRIPTION
The Queue API in the portability layer was useless wasting memory by always allocating the maximum amount of memory for each elements. In retrospect, this was pretty stupid. This fixes this by adding size arguments to Send/Receive methods.

Close #67