### PR TITLE
Fix build issues with IDF ver5 w/multiple target install

### DIFF
--- a/components/FreeRTOS-Plus-POSIX/CMakeLists.txt
+++ b/components/FreeRTOS-Plus-POSIX/CMakeLists.txt
@@ -3,6 +3,17 @@
 file(TO_CMAKE_PATH "$ENV{IDF_PATH}" ENV_IDF_PATH)
 
 # set(esp_idf_dir $ENV{IDF_PATH})
+
+if (EXISTS "${ENV_IDF_PATH}/components/freertos/include/freertos")
+  set(FREERTOS_INCLUDES "${ENV_IDF_PATH}/components/freertos/include/freertos")
+else()
+  if(CONFIG_FREERTOS_SMP)
+    set(FREERTOS_INCLUDES "${ENV_IDF_PATH}/components/freertos/FreeRTOS-Kernel-SMP/include/freertos")
+  else()
+    set(FREERTOS_INCLUDES "${ENV_IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+  endif()
+endif()
+
 idf_component_register(
   SRC_DIRS "FreeRTOS-Plus-POSIX/source"
   INCLUDE_DIRS
@@ -11,10 +22,9 @@ idf_component_register(
   "FreeRTOS-Plus-POSIX/include"
   "FreeRTOS-Plus-POSIX/include/portable/espressif/esp32_devkitc_esp_wrover_kit"
   "FreeRTOS-Plus-POSIX/include/portable"
-
   PRIV_INCLUDE_DIRS
   "include/private"
-  "${ENV_IDF_PATH}/components/freertos/include/freertos"
+  "${FREERTOS_INCLUDES}"
 )
 
 # set_source_files_properties("${freertos_plus_posix_dir}/source/FreeRTOS_POSIX_pthread_cond.c"

--- a/components/NetworkInterface/esp32/NetworkInterface.c
+++ b/components/NetworkInterface/esp32/NetworkInterface.c
@@ -26,7 +26,9 @@
 /* ESP includes.*/
 #include "esp_log.h"
 #include "esp_wifi.h"
-//#include "esp_mac.h"
+#if ESP_IDF_VERSION_MAJOR > 4
+#include "esp_mac.h"
+#endif
 #include "esp_event.h"
 #include "esp_system.h"
 #include "esp_event_base.h"

--- a/main/main.c
+++ b/main/main.c
@@ -21,6 +21,7 @@
 #include "esp_system.h"
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "nvs_flash.h"
 
 #define TAG_APP "[PING-APP]"
@@ -124,7 +125,7 @@ void app_main(void)
 
                     time_delta = time2 - time1;
 
-                    ns = (t2 - t1) / portTICK_RATE_MS;
+                    ns = (t2 - t1) / portTICK_PERIOD_MS;
 
                     // ESP_LOGI(TAG_APP, "%d bytes from server: rtt = %.3f ms\n", uxRxBytes, ns);
                     ESP_LOGI(TAG_APP, "%d bytes from server: rtt = %d us\n", uxRxBytes, time_delta);
@@ -132,7 +133,7 @@ void app_main(void)
                 }
             }
 
-            vTaskDelay(1000 / portTICK_RATE_MS);
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
             i = i + 1;
         }
     }


### PR DESCRIPTION
These changes fix Rinasense compilation problems when you are using IDF Version 5, installed for multiple targets.  (Tested on Ubuntu 20.04.)  The fixes should be compatible with all Version 4 installations, but the only one I was able to test against was on Mac.  The Mac still has later Python-related build problems, but they occur after the build is past these compilation errors.

(OT: There are known Python problems with the IDF on MacOS Monterey.  I have had to make one change so far to the IDF itself on Monterey, and more may be needed.  I'll eventually file an issue on that in case someone else wants to use Monterey and include the fixes.)

This fixes issue #35.