### PR TITLE
#3: Convert RINAStackEvent_t into an Union type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if("${TARGET_TYPE}" STREQUAL "" OR "${TARGET_TYPE}" STREQUAL "freertos_idf")
 
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)
     add_compile_definitions(configUSE_POSIX_ERRNO=1)
-    add_compile_definitions(
+    add_compile_options(
       -Wno-unused-but-set-variable
       -Wno-unused-function
       -Wno-unused-variable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,21 +245,22 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
   include("${BufferManagement_TEST_DIR}/CMakeLists.txt")
 
   #
-  # Component: NetworkInterface
+  # Component: NetworkInterface (various)
   #
-  # FIXME: The 'mq' NetworkInterface is for testing only. We need to
-  # figure out how to support multiple type of NetworkInterface.
   set(NetworkInterface_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/NetworkInterface")
-  file(GLOB NetworkInterface_SOURCES
-   "${NetworkInterface_DIR}/mq/*.c"
+  file(GLOB NetworkInterface_MQ_SOURCES
+    "${NetworkInterface_DIR}/mq/*.c"
   )
-  add_library(NetworkInterface STATIC ${NetworkInterface_SOURCES})
-  target_include_directories(NetworkInterface PUBLIC
+  file(GLOB NetworkInterface_TAP_SOURCES
+    "${NetworkInterface_DIR}/linux_tap/*.c"
+  )
+  add_library(NetworkInterface_MQ STATIC ${NetworkInterface_MQ_SOURCES})
+  add_library(NetworkInterface_TAP STATIC ${NetworkInterface_TAP_SOURCES})
+  set(NetworkInterface_Common_INCLUDES
     ${Common_INCLUDES}
     ${configRINA_INCLUDES}
     ${BufferManagement_INCLUDES}
     ${NetworkInterface_INCLUDES}
-    ${NetworkInterface_MQ_INCLUDES}
     ${ARP826_INCLUDES}
     ${IPCP_INCLUDES}
     ${configSensor_INCLUDES}
@@ -269,11 +270,23 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
     ${Portability_INCLUDES}
     ${RINA_API_INCLUDES}
   )
-  target_link_libraries(NetworkInterface PUBLIC
+  target_link_libraries(NetworkInterface_MQ PUBLIC
     Common
+  )
+  target_link_libraries(NetworkInterface_TAP PUBLIC
+    Common
+  )
+
+  target_include_directories(NetworkInterface_MQ PUBLIC
+    ${NetworkInterface_Common_INCLUDES}
+    ${NetworkInterface_MQ_INCLUDES}
+  )
+  target_include_directories(NetworkInterface_TAP PUBLIC
+    ${NetworkInterface_Common_INCLUDES}
   )
   include("${NetworkInterface_DIR}/test/CMakeLists.txt")
 
+  #
   # Component: ARP826
   #
   set(ARP826_DIR "${CMAKE_CURRENT_SOURCE_DIR}/components/ARP826")
@@ -291,7 +304,6 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
     ${ShimIPCP_INCLUDES}
   )
   target_link_libraries(ARP826 PUBLIC
-    NetworkInterface
     Common
     BufferManagement
     IPCP
@@ -376,7 +388,6 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
     BufferManagement
     EFCP
     IPCP
-    NetworkInterface
     Rmt
   )
   include("${ShimIPCP_TESTS_DIR}/CMakeLists.txt")
@@ -409,7 +420,6 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
   )
   target_link_libraries(IPCP PUBLIC
     ARP826
-    NetworkInterface
     ShimIPCP
     BufferManagement
     Rmt
@@ -547,6 +557,7 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3 -O0 -include stdbool.h")
 
   add_subdirectory(unity)
+  add_subdirectory(test_linux)
 
 else()
   message("Unknown target ${TARGET_TYPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ if("${TARGET_TYPE}" STREQUAL "" OR "${TARGET_TYPE}" STREQUAL "freertos_idf")
 
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)
     add_compile_definitions(configUSE_POSIX_ERRNO=1)
+    add_compile_definitions(
+      -Wno-unused-but-set-variable
+      -Wno-unused-function
+      -Wno-unused-variable
+      -Wno-unused-parameter
+    )
+
     project(RINA_sensor)
   else()
     message(FATAL_ERROR "The 'freertos_idf' target needs the IDF_PATH environment variable to be defined")
@@ -30,6 +37,28 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
   include(CTest)
 
   add_compile_definitions(configUSE_POSIX_ERRNO=1)
+
+  add_compile_options(
+    -Wall -Werror -Wextra
+
+    # Disable some warnings while development is active. It drowns the
+    # other more important warnings.
+    -Wno-unused-but-set-variable
+    -Wno-unused-function
+    -Wno-unused-variable
+    -Wno-unused-parameter
+
+    # Debugging information
+    -ggdb3
+
+    # Disables optimisation
+    -O0
+
+    # Automatically add 'stdbool.h' as an include file to all
+    # files. It is a bit weird to add it here so maybe I should
+    # consider including it in the Portability component, or in Common
+    -include stdbool.h
+  )
 
   set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -114,6 +143,7 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
     ${Portability_INCLUDES}
     ${IPCP_INCLUDES}
     ${Rmt_INCLUDES}
+    ${RINA_API_INCLUDES}
   )
 
   file(GLOB mock_FlowAllocator_SOURCES
@@ -237,6 +267,7 @@ elseif (${TARGET_TYPE} STREQUAL "linux")
     ${ShimIPCP_INCLUDES}
     ${EFCP_INCLUDES}
     ${Portability_INCLUDES}
+    ${RINA_API_INCLUDES}
   )
   target_link_libraries(NetworkInterface PUBLIC
     Common

--- a/components/ARP826/ARP826.c
+++ b/components/ARP826/ARP826.c
@@ -331,9 +331,10 @@ bool_t vARPSendRequest(gpa_t *pxTpa, gpa_t *pxSpa, gha_t *pxSha)
 
 	pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(xBufferSize, 0);
 
-	if (pxNetworkBuffer != NULL)
-	{
-		pxNetworkBuffer->ulGpa = pxTpa->pucAddress;
+	if (pxNetworkBuffer != NULL) {
+        /* FIXME: This assignment makes no sense and the compiler
+           complains about it. */
+		/*pxNetworkBuffer->ulGpa = pxTpa->pucAddress; */
 
 		prvARPGeneratePacket(pxNetworkBuffer, pxSha, pxSpa, pxTpa, ARP_REQUEST);
 

--- a/components/ARP826/ARP826.c
+++ b/components/ARP826/ARP826.c
@@ -353,7 +353,7 @@ bool_t vARPSendRequest(gpa_t *pxTpa, gpa_t *pxSpa, gha_t *pxSha)
 
 			/* Send a message to the IPCP-task to send this ARP packet. */
 			xSendEvent.eEventType = eNetworkTxEvent;
-			xSendEvent.pvData = pxNetworkBuffer;
+			xSendEvent.xData.PV = (void *)pxNetworkBuffer;
 
 			if (!xSendEventStructToIPCPTask(&xSendEvent, 1000))
 			{

--- a/components/ARP826/ARP826.c
+++ b/components/ARP826/ARP826.c
@@ -445,7 +445,7 @@ static void prvARPGeneratePacket(NetworkBufferDescriptor_t *const pxNetworkBuffe
 	pxARPPacket->xARPHeader.ucHALength = sizeof(pxSha->xAddress.ucBytes);
 	pxARPPacket->xARPHeader.ucPALength = pxSpa->uxLength;
 	pxARPPacket->xARPHeader.usOperation = usPtype;
-	pxARPPacket->xEthernetHeader.usFrameType = RsHtoNS(ETH_P_ARP);
+	pxARPPacket->xEthernetHeader.usFrameType = RsHtoNS(ETH_P_RINA_ARP);
 
 	memcpy(pxARPPacket->xEthernetHeader.xSourceAddress.ucBytes, pxSha->xAddress.ucBytes, sizeof(pxSha->xAddress));
 	memcpy(pxARPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxTha->xAddress.ucBytes, sizeof(pxTha->xAddress));

--- a/components/ARP826/test/CMakeLists.txt
+++ b/components/ARP826/test/CMakeLists.txt
@@ -6,6 +6,7 @@ else()
   add_executable(test_arp826 "${CMAKE_CURRENT_LIST_DIR}/test_arp826.c")
   target_link_libraries(test_arp826 PUBLIC
     ARP826
+    NetworkInterface_MQ
     unity
   )
 

--- a/components/ARP826/test/test_arp826.c
+++ b/components/ARP826/test/test_arp826.c
@@ -42,7 +42,7 @@ const MACAddress_t mac2 = {
 RS_TEST_CASE_SETUP(test_arp826)
 {
     /* Initialize the test packet. */
-    p1.xEthernetHeader.usFrameType = RsHtoNS(ETH_P_ARP);
+    p1.xEthernetHeader.usFrameType = RsHtoNS(ETH_P_RINA_ARP);
     p1.xARPHeader.usHType = RsHtoNS(0x0001);
     p1.xARPHeader.usPType = RsHtoNS(ETH_P_RINA);
 

--- a/components/BufferManagement/BufferManagement.c
+++ b/components/BufferManagement/BufferManagement.c
@@ -36,8 +36,6 @@
 STATIC_ASSERT(ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE);
 #endif
 
-int count = 0;
-
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
 static RsList_t xFreeBuffersList;
 
@@ -201,7 +199,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 
     if (xTimeOutUS > 0) {
         if (!rstime_waitusec(&ts, xTimeOutUS)) {
-            LOGE(TAG_NETBUFFER, "Error scheduling buffer waiting time");
+            LOGD(TAG_NETBUFFER, "Error scheduling buffer waiting time");
             return NULL;
         }
 
@@ -257,6 +255,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                 /* The attempt to allocate storage for the buffer payload failed,
                  * so the network buffer structure cannot be used and must be
                  * released. */
+                LOGD(TAG_NETBUFFER, "Failed to attach buffer to descriptor");
                 vReleaseNetworkBufferAndDescriptor(pxReturn);
                 pxReturn = NULL;
             }
@@ -289,9 +288,9 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
     }
 
     if (pxReturn != NULL)
-        LOGI(TAG_NETBUFFER, "Count: %u", (unsigned int)uxCount);
+        LOGD(TAG_NETBUFFER, "Free descriptor Count: %u", (unsigned int)uxCount);
     else
-        LOGE(TAG_NETBUFFER, "Failed to return descriptor");
+        LOGD(TAG_NETBUFFER, "pxGetNetworkBufferWithDescriptor returned NULL");
 
     return pxReturn;
 }
@@ -299,7 +298,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 
 void vReleaseNetworkBufferAndDescriptor(NetworkBufferDescriptor_t *const pxNetworkBuffer)
 {
-    bool_t xListItemAlreadyInFreeList;
+    bool_t xAlreadyInFreeList;
 
     /* Ensure the buffer is returned to the list of free buffers before the
      * counting semaphore is 'given' to say a buffer is available.  Release the
@@ -312,17 +311,10 @@ void vReleaseNetworkBufferAndDescriptor(NetworkBufferDescriptor_t *const pxNetwo
 
     pthread_mutex_lock( &mutex );
     {
-        xListItemAlreadyInFreeList = xRsListIsContainedWithin( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ));
+        xAlreadyInFreeList = xRsListIsContainedWithin( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ));
 
-        if( xListItemAlreadyInFreeList == false )
-        {
+        if( !xAlreadyInFreeList )
             vRsListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
-
-#ifndef NDEBUG
-            /* Zero the buffer to facilitate debugging. */
-            memset(pxNetworkBuffer->pucDataBuffer, 0, pxNetworkBuffer->xDataLength);
-#endif
-        }
     }
     pthread_mutex_unlock( &mutex );
 
@@ -330,19 +322,8 @@ void vReleaseNetworkBufferAndDescriptor(NetworkBufferDescriptor_t *const pxNetwo
      * Update the network state machine, unless the program fails to release its 'xNetworkBufferSemaphore'.
      * The program should only try to release its semaphore if 'xListItemAlreadyInFreeList' is false.
      */
-    if( xListItemAlreadyInFreeList == false )
-    {
-        if( sem_post( &xNetworkBufferSemaphore ) == 0 )
-        {
-        }
-    }
-    else
-    {
-        /* No action. */
-    }
-    count = count - 1;
-    // ESP_LOGI(TAG_NETBUFFER, "Releasing Buffer....!!!");
-    // ESP_LOGI(TAG_NETBUFFER, "Buffer actived:%d", count);
+    if( !xAlreadyInFreeList && sem_post( &xNetworkBufferSemaphore ) == 0 )
+        LOGD(TAG_NETBUFFER, "Successfully released buffer");
 }
 /*-----------------------------------------------------------*/
 

--- a/components/BufferManagement/BufferManagement.c
+++ b/components/BufferManagement/BufferManagement.c
@@ -36,9 +36,6 @@
 STATIC_ASSERT(ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE);
 #endif
 
-
-#define BUFFER_PADDING 0U
-
 int count = 0;
 
 /* A list of free (available) NetworkBufferDescriptor_t structures. */

--- a/components/Common/include/common/rina_ids.h
+++ b/components/Common/include/common/rina_ids.h
@@ -4,12 +4,7 @@
 #include <stdint.h>
 #include "portability/port.h"
 
-#define PORT_ID_WRONG -1
-#define CEP_ID_WRONG -1
-#define ADDRESS_WRONG -1
-#define QOS_ID_WRONG -1
-
-typedef int32_t  portId_t;
+typedef uint32_t portId_t;
 
 typedef uint32_t seqNum_t;
 
@@ -24,57 +19,41 @@ typedef uint8_t address_t;
 
 typedef uint16_t ipcProcessId_t;
 
-typedef uint16_t ipcpInstanceId_t;
-
-typedef unsigned int uint_t; // WHY?
-typedef unsigned int timeout_t;
-
-static inline portId_t port_id_bad(void)
-{
-        return PORT_ID_WRONG;
-}
+#define PORT_ID_WRONG (portId_t)-1
+#define CEP_ID_WRONG  (cepId_t)-1
+#define ADDRESS_WRONG (address_t)-1
+#define QOS_ID_WRONG  (qosId_t)-1
+#define IPCP_ID_WRONG (ipcProcessId_t)-1
 
 static inline bool_t is_port_id_ok(portId_t id)
 {
-        return id >= 0 ? true : false;
+    return id != PORT_ID_WRONG;
 }
 
 static inline bool_t is_cep_id_ok(cepId_t id)
 {
-        return id >= 0 ? true : false;
+    return id != CEP_ID_WRONG;
 }
 
 static inline bool_t is_ipcp_id_ok(ipcProcessId_t id)
 {
-        return id >= 0 ? true : false;
+    return id != IPCP_ID_WRONG;
 }
 
 static inline bool_t is_address_ok(address_t address)
 {
-        return address != ADDRESS_WRONG ? true : false;
+    return address != ADDRESS_WRONG;
 }
 
 static inline bool_t is_qos_id_ok(qosId_t id)
 {
-        return id != QOS_ID_WRONG ? true : false;
+    return id != QOS_ID_WRONG;
 }
 
-/* Kept for porting, but, really, are those necessary? */
+/* Unclear if the definitions below are useful. */
 
-static inline cepId_t cep_id_bad(void)
-{
-        return CEP_ID_WRONG;
-}
-
-static inline address_t address_bad(void)
-{
-        return ADDRESS_WRONG;
-}
-
-static inline qosId_t qos_id_bad(void)
-{
-        return QOS_ID_WRONG;
-}
-
+typedef unsigned int uint_t; 
+typedef unsigned int timeout_t;
+typedef uint16_t ipcpInstanceId_t;
 
 #endif // _COMMON_RINA_IDS_H

--- a/components/Common/include/common/rsrc.h
+++ b/components/Common/include/common/rsrc.h
@@ -63,7 +63,7 @@ struct rsrcPool {
 	rsrcFreeHelper_t	*pxFreeHelper;
 	rsrcPrintHelper_t	*pxPrintHelper;
 	const char	*pcName;			// lifetime must be >= that of the rsrcPool
-	uint64_t	ulTotalAllocs;
+	uintmax_t	ulTotalAllocs;
 	size_t		uxSizeEach;			// sizeof of the resource type, 0 if variable
 	uint16_t	uiIncrement;		// additional to allocate when free list empty
 	uint16_t	uiFreeOnFree;		// nonzero for dynamic pools

--- a/components/Common/list.c
+++ b/components/Common/list.c
@@ -5,7 +5,6 @@
 bool_t xRsListIsContainedWithin(RsList_t *const pxList, RsListItem_t *const pxItem)
 {
     RsListItem_t *pItem;
-    void *pvOwner;
 
     pItem = pxRsListGetFirst(pxList);
 

--- a/components/Common/rina_gpha.c
+++ b/components/Common/rina_gpha.c
@@ -101,7 +101,7 @@ gpa_t *pxCreateGPA(const buffer_t pucAddress, size_t uxLength)
 	memcpy(pxGPA->pucAddress, pucAddress, pxGPA->uxLength);
 
 	LOGI(TAG_SHIM, "CREATE GPA address: %s", pxGPA->pucAddress);
-	LOGI(TAG_SHIM, "CREATE GPA size: %u", pxGPA->uxLength);
+	LOGI(TAG_SHIM, "CREATE GPA size: %zu", pxGPA->uxLength);
 
 	return pxGPA;
 }

--- a/components/Common/rina_name.c
+++ b/components/Common/rina_name.c
@@ -53,9 +53,9 @@ void vRstrNameDestroy(name_t *pxName)
 
         vRstrNameFini(pxName);
 
-        vRsMemFree(pxName);
+        LOGI(TAG_RINA_NAME, "Name at %pK destroyed", pxName);
 
-        LOGI(TAG_RINA_NAME, "Name at %pK destroyed successfully", pxName);
+        vRsMemFree(pxName);
 }
 
 void vRstrNameFree(name_t *xName)
@@ -103,7 +103,7 @@ char *pcRstrDup(const char *s)
                 return NULL;
 
         len = strlen(s) + 1;
-        LOGE(TAG_RINA_NAME, "Len RstrDup:%d", len);
+        LOGE(TAG_RINA_NAME, "Len RstrDup: %zu", len);
         buf = pvRsMemAlloc(len);
         memset(buf,0,len);
         if (buf)
@@ -327,10 +327,10 @@ name_t *pxRstrNameDup(const name_t *pxSrc)
 
 string_t pcNameToString(const name_t *n)
 {
-    char *       tmp;
-    size_t       size;
-    const char * none     = "";
-    size_t       none_len = strlen(none);
+    char *         tmp;
+    size_t         size;
+    const string_t none = "";
+    size_t         none_len = strlen(none);
 
     if (!n)
         return NULL;
@@ -368,7 +368,7 @@ string_t pcNameToString(const name_t *n)
                  (n->pcEntityName      ? n->pcEntityName      : none),
                  DELIMITER,
                  (n->pcEntityInstance  ? n->pcEntityInstance  : none)) !=
-        size - 1) {
+        (int)(size - 1)) {
         vRsMemFree(tmp);
         return NULL;
     }

--- a/components/Common/rsrc.c
+++ b/components/Common/rsrc.c
@@ -351,7 +351,7 @@ static int prviRsrcAdd2Pool (rsrcPoolP_t pxPool, unsigned int uiCount, size_t xR
 	if (pxPool->uiNumInUse + pxPool->uiNumFree == 0)
 		pxPool->uiLowWater = uiCount;	// only happens once, at first allocation
 	
-	for (int i = 0; i < uiCount; i++, space += xResSize) {
+	for (unsigned int i = 0; i < uiCount; i++, space += xResSize) {
 		struct rsrc *rsrc = (struct rsrc *)space;
 		
 		prvvFreeResTail (pxPool, rsrc, 0); // FIXME! Is 0 right on new ones?
@@ -411,7 +411,7 @@ void vRsrcDefaultPrintPoolHelper (rsrcPoolP_t pxOwningPool, void *pxPool2Print)
 {
 	rsrcPoolP_t pxPool = (rsrcPoolP_t) pxPool2Print;
 	
-	logPrintf(TAG, "=== Pool %s: %llu(Tot), %u(A), %u(AHi), %u(F), %u(FLo)",
+	logPrintf(TAG, "=== Pool %s: %ju(Tot), %u(A), %u(AHi), %u(F), %u(FLo)",
 			  pxPool->pcName, pxPool->ulTotalAllocs, pxPool->uiNumInUse,
 			  pxPool->uiHiWater, pxPool->uiNumFree, pxPool->uiLowWater);
 }
@@ -432,7 +432,7 @@ void prvvRsrcPrintCom (rsrcPoolP_t pxPool2Print, int iPrintRsrcs)
 		rsrcPoolP_t pxPool = (rsrcPoolP_t)pxPoolWalker;
 		if (pxPool2Print && pxPool2Print != pxPool) // ignore uninteresting pools
 			continue;
-		DEBUGPRINTF(TAG, "%s: %llu(Tot), %u(A), %u(AHi), %u(F), %u(FLo)\n",
+		DEBUGPRINTF(TAG, "%s: %ju(Tot), %u(A), %u(AHi), %u(F), %u(FLo)\n",
 				  pxPool->pcName, pxPool->ulTotalAllocs,
 				  pxPool->uiNumInUse, pxPool->uiHiWater, pxPool->uiNumFree, pxPool->uiLowWater);
 		if (xRsrcPoolPool.pxPrintHelper) {
@@ -558,7 +558,7 @@ void vRsrcPrintResInHexHelper (rsrcPoolP_t pxPool, void *pvRsrcPayload)
 		for (int i = 0; i < numtoprint; i++) {
 			logPrintf (TAG, "%08x ", pi[i]);
 		}
-		for (int i = 0; i < (numtoprint*(sizeof (int))); i++) {
+		for (unsigned int i = 0; i < (numtoprint*(sizeof (int))); i++) {
 			c = (*pi >> (24 - i*8)) & 0xff;
 			if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
 				(c >= '0' && c <= '9')) {

--- a/components/Common/test/CMakeLists.txt
+++ b/components/Common/test/CMakeLists.txt
@@ -38,6 +38,18 @@ else()
     unity
   )
 
+  add_executable(test_ids "${CMAKE_CURRENT_LIST_DIR}/test_ids.c")
+  target_link_libraries(test_ids
+    Common
+    portability
+    unity
+  )
+
+  add_test(
+    NAME "test_ids"
+    COMMAND "./test_ids"
+  )
+
   add_test(
     NAME test_lists
     COMMAND "./test_lists"

--- a/components/Common/test/test_bit_array.c
+++ b/components/Common/test/test_bit_array.c
@@ -55,7 +55,7 @@ RS_TEST_CASE(BitArrayLarge, "[bitarray]")
         vBitArraySetBit(ba, i);
 
     for (int i = 0; i < (10000 / 32) - 1; i++)
-        TEST_ASSERT(*(uint32_t *)((void *)ba + sizeof(bitarray_t) + i * sizeof(uint32_t)) == -1);
+        TEST_ASSERT(*(uint32_t *)((void *)ba + sizeof(bitarray_t) + i * sizeof(uint32_t)) == (uint32_t)-1);
 
     vBitArrayFree(ba);
 

--- a/components/Common/test/test_ids.c
+++ b/components/Common/test/test_ids.c
@@ -1,0 +1,61 @@
+#include <limits.h>
+
+#include "common/rina_ids.h"
+
+#include "unity.h"
+#include "common/unity_fixups.h"
+
+RS_TEST_CASE_SETUP(test_ids) {}
+RS_TEST_CASE_TEARDOWN(test_ids) {}
+
+RS_TEST_CASE(ValidInvalid, "[ids]")
+{
+    /* Good port values. */
+    TEST_ASSERT(is_port_id_ok(0));
+    TEST_ASSERT(is_port_id_ok(((portId_t)-1) - 1));
+
+    /* Bad port values */
+    TEST_ASSERT(!is_port_id_ok((portId_t)-1));
+    TEST_ASSERT(!is_port_id_ok(PORT_ID_WRONG));
+
+    /* Good CEP ID values. */
+    TEST_ASSERT(is_cep_id_ok(0));
+    TEST_ASSERT(is_cep_id_ok((cepId_t)-1) - 1);
+
+    /* Bad CEP ID values. */
+    TEST_ASSERT(!is_cep_id_ok((cepId_t)-1));
+    TEST_ASSERT(!is_cep_id_ok(CEP_ID_WRONG));
+
+    /* Good IPCP ID values. */
+    TEST_ASSERT(is_ipcp_id_ok(0));
+    TEST_ASSERT(is_ipcp_id_ok(((ipcProcessId_t)-1) - 1));
+
+    /* Bad IPCP ID Values. */
+    TEST_ASSERT(!is_ipcp_id_ok((ipcProcessId_t)-1));
+    TEST_ASSERT(!is_ipcp_id_ok(IPCP_ID_WRONG));
+
+    /* Good address values */
+    TEST_ASSERT(is_address_ok(0));
+    TEST_ASSERT(is_address_ok(((address_t)-1) - 1));
+
+    /* Bad address values */
+    TEST_ASSERT(!is_address_ok((address_t)-1));
+    TEST_ASSERT(!is_address_ok(ADDRESS_WRONG));
+
+    /* Good QOS ID values. */
+    TEST_ASSERT(is_qos_id_ok(0));
+    TEST_ASSERT(is_qos_id_ok(((qosId_t)-1) - 1));
+
+    /* Bad QOS ID values. */
+    TEST_ASSERT(!is_qos_id_ok((qosId_t)-1));
+    TEST_ASSERT(!is_qos_id_ok(QOS_ID_WRONG));
+}
+
+#ifndef TEST_CASE
+int main()
+{
+    RS_SUITE_BEGIN();
+    RS_RUN_TEST(ValidInvalid);
+    RS_SUITE_END();
+}
+#endif

--- a/components/Common/test/test_ids.c~
+++ b/components/Common/test/test_ids.c~
@@ -1,3 +1,0 @@
-
-RS_TEST_CASE_SETUP(test_ids) {}
-RS_TEST_CASE_TEARDOWN(test_ids) {}

--- a/components/Common/test/test_ids.c~
+++ b/components/Common/test/test_ids.c~
@@ -1,0 +1,3 @@
+
+RS_TEST_CASE_SETUP(test_ids) {}
+RS_TEST_CASE_TEARDOWN(test_ids) {}

--- a/components/Common/test/test_lists.c
+++ b/components/Common/test/test_lists.c
@@ -13,11 +13,15 @@ struct item {
     RsListItem_t item;
 };
 
-struct item i1 = { 1 }, i2 = { 3 }, i3 = { 10 };
+struct item i1, i2, i3;
 
 /* This ain't a test! */
 void addBogusItems(RsList_t *lst)
 {
+    i1.n = 1;
+    i2.n = 3;
+    i3.n = 100;
+
     vRsListInit(lst);
     vRsListInitItem(&(i1.item), &i1);
     vRsListInitItem(&(i2.item), &i2);
@@ -30,7 +34,6 @@ RS_TEST_CASE(ListBasics, "[list]")
 {
     RsList_t lst;
     RsListItem_t *pLstItem = NULL;
-    struct item *pItem;
 
     RS_TEST_CASE_BEGIN(test_lists);
 
@@ -101,7 +104,7 @@ RS_TEST_CASE(ListIteration, "[list]")
 {
     RsList_t lst;
     struct item *pos;
-    RsListItem_t *pEnd, *pItem;
+    RsListItem_t *pItem;
     int n = 0;
 
     RS_TEST_CASE_BEGIN(test_lists);

--- a/components/EFCP/EFCP.c
+++ b/components/EFCP/EFCP.c
@@ -147,10 +147,10 @@ static bool_t xEfcpDestroy(struct efcp_t *pxInstance)
                 delim_destroy(pxInstance->delim);
         }*/
 
+        LOGI(TAG_EFCP, "EFCP instance %pK finalized successfully", pxInstance);
+
         /*robject_del(&instance->robj);*/
         vRsMemFree(pxInstance);
-
-        LOGI(TAG_EFCP, "EFCP instance %pK finalized successfully", pxInstance);
 
         return true;
 }
@@ -700,6 +700,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         }
 
         pxDtcp = NULL;
+
 #if 0
         rcu_read_lock();
         dtp_ps = dtp_ps_get(efcp->dtp);

--- a/components/EFCP/EFCP.c
+++ b/components/EFCP/EFCP.c
@@ -602,10 +602,9 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         // struct rttq *       rttq;
         // struct delim * delim;
 
-        if (!pxEfcpContainer)
-        {
-                LOGE(TAG_EFCP, "Bogus container passed, bailing out");
-                return cep_id_bad();
+        if (!pxEfcpContainer) {
+                LOGE(TAG_EFCP,"Bogus container passed, bailing out");
+                return CEP_ID_WRONG;
         }
 
         LOGE(TAG_EFCP, "xEfcpConnectionCreate: ConnectionCreate");
@@ -617,7 +616,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         RsAssert(pxConnection);
 
         if (!pxConnection)
-                return cep_id_bad();
+                return CEP_ID_WRONG;
 
         RsAssert(pxDtpCfg);
 
@@ -634,7 +633,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         if (!pxEfcp)
         {
                 xConnectionDestroy(pxConnection);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         // xCepId = cidm_allocate(container->cidm);
@@ -644,7 +643,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         {
                 LOGE(TAG_EFCP, "CIDM generated wrong CEP ID");
                 xEfcpDestroy(pxEfcp);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         /* We must ensure that the DTP is instantiated, at least ... */
@@ -656,7 +655,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         {
                 LOGE(TAG_EFCP, "Bogus connection passed, bailing out");
                 xEfcpDestroy(pxEfcp);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         pxEfcp->pxConnection = pxConnection;
@@ -668,7 +667,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         	if (!delim){
         		LOGE(TAG_EFCP,"Problems creating delimiting module");
                         xEfcpDestroy(pxEfcp);
-                        return cep_id_bad();
+                        return CEP_ID_WRONG;
         	}
 
         	delim->max_fragment_size =
@@ -682,7 +681,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                         	RINA_PS_DEFAULT_NAME);
                         delim_destroy(delim);
                         efcp_destroy(efcp);
-                        return cep_id_bad();
+                        return CEP_ID_WRONG;
                 }
 
         	pxEfcp->pxDelim = delim;
@@ -697,7 +696,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         if (!pxEfcp->pxDtp)
         {
                 xEfcpDestroy(pxEfcp);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         pxDtcp = NULL;
@@ -714,7 +713,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
 				   &efcp->robj);
                 if (!dtcp) {
                         efcp_destroy(efcp);
-                        return cep_id_bad();
+                        return CEP_ID_WRONG;
                 }
 
                 efcp->dtp->dtcp = dtcp;
@@ -726,7 +725,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                 if (!cwq) {
                         LOGE(TAG_EFCP,"Failed to create closed window queue");
                         efcp_destroy(efcp);
-                        return cep_id_bad();
+                        return CEP_ID_WRONG;
                 }
                 efcp->dtp->cwq = cwq;
         }
@@ -737,7 +736,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                 if (!rtxq) {
                         LOGE(TAG_EFCP,"Failed to create rexmsn queue");
                         efcp_destroy(efcp);
-                        return cep_id_bad();
+                        return CEP_ID_WRONG;
                 }
                 efcp->dtp->rtxq = rtxq;
                 efcp->dtp->rttq = NULL;
@@ -746,7 +745,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
         	if (!rttq) {
         		LOGE(TAG_EFCP,"Failed to create RTT queue");
         		efcp_destroy(efcp);
-        		return cep_id_bad();
+        		return CEP_ID_WRONG;
         	}
         	efcp->dtp->rttq = rttq;
         	efcp->dtp->rtxq = NULL;
@@ -782,7 +781,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
 			mfps, mfss, mpl, a, r, tr)) {
                 LOGE(TAG_EFCP,"Could not init dtp_sv");
                 efcp_destroy(efcp);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
 #endif
@@ -792,7 +791,7 @@ cepId_t xEfcpConnectionCreate(struct efcpContainer_t *pxEfcpContainer,
                 LOGE(TAG_EFCP, "Cannot add a new instance into container %p",
                      pxEfcpContainer);
                 xEfcpDestroy(pxEfcp);
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         LOGI(TAG_EFCP, "Connection created ("

--- a/components/EFCP/dtp.c
+++ b/components/EFCP/dtp.c
@@ -438,10 +438,10 @@ bool_t xDtpDestroy(dtp_t *pxInstance)
                 pxInstance->pxDtcp = NULL; /* Useful */
         }
 
+        LOGI(TAG_DTP, "DTP %pK destroyed successfully", pxInstance);
+
         // robject_del(&instance->robj);
         vRsMemFree(pxInstance);
-
-        LOGI(TAG_DTP, "DTP %pK destroyed successfully", pxInstance);
 
         return true;
 }

--- a/components/Enrollment/SerdesMsg.c
+++ b/components/Enrollment/SerdesMsg.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 /* RINA includes. */
 #include "portability/rsmem.h"
@@ -19,6 +20,18 @@
 #include "Rib.h"
 #include "FlowMessage.pb.h"
 #include "FlowAllocator.h"
+
+#ifdef __LONG_WIDTH__
+#if __LONG_WIDTH__ == 32
+#define ULONG_FMT "%llu"
+#elif __LONG_WIDTH__ == 64
+#define ULONG_FMT "%lu"
+#else
+#error Not sure how to handle this __LONG_WIDTH__
+#endif
+#else
+#error __LONG_WIDTH__ is not defined
+#endif
 
 /**
  * @brief Encode a Enrollment message and return the serialized object value to be
@@ -417,12 +430,13 @@ static flow_t *prvSerdesMsgDecodeFlow(rina_messages_Flow message)
 
     return pxMessage;
 }
+
 void prvPrintDecodeFlow(rina_messages_Flow message)
 {
     LOGI(TAG_RIB, "--------Flow Message--------");
 
     if (message.has_destinationAddress)
-        LOGI(TAG_RIB, "Destination Address:%lld", message.destinationAddress);
+        LOGI(TAG_RIB, "Destination Address:"ULONG_FMT, message.destinationAddress);
 
     LOGI(TAG_RIB, "Destination PN:%s", message.destinationNamingInfo.applicationProcessName);
     if (message.destinationNamingInfo.has_applicationEntityName)
@@ -432,9 +446,10 @@ void prvPrintDecodeFlow(rina_messages_Flow message)
     if (message.destinationNamingInfo.has_applicationProcessInstance)
         LOGI(TAG_RIB, "Destination PI:%s", message.destinationNamingInfo.applicationProcessInstance);
     if (message.has_destinationPortId)
-        LOGI(TAG_RIB, "Destination PortId:%lld", message.destinationPortId);
+        LOGI(TAG_RIB, "Destination PortId:"ULONG_FMT, message.destinationPortId);
 
-    LOGI(TAG_RIB, "Source Address:%lld", message.sourceAddress);
+    LOGI(TAG_RIB, "Source Address:"ULONG_FMT, message.sourceAddress);
+
     LOGI(TAG_RIB, "Source PN:%s", message.sourceNamingInfo.applicationProcessName);
     if (message.sourceNamingInfo.has_applicationEntityName)
         LOGI(TAG_RIB, "Source EN:%s", message.sourceNamingInfo.applicationEntityName);
@@ -443,7 +458,7 @@ void prvPrintDecodeFlow(rina_messages_Flow message)
     if (message.sourceNamingInfo.has_applicationProcessInstance)
         LOGI(TAG_RIB, "Source PI:%s", message.sourceNamingInfo.applicationProcessInstance);
 
-    LOGI(TAG_RIB, "Source PortId:%lld", message.sourcePortId);
+    LOGI(TAG_RIB, "Source PortId:"ULONG_FMT, message.sourcePortId);
 
     if (message.connectionIds->has_destinationCEPId)
         LOGI(TAG_RIB, "Connection Dest Cep Id:%d", (int)message.connectionIds->destinationCEPId);

--- a/components/IPCP/IPCP.c
+++ b/components/IPCP/IPCP.c
@@ -319,7 +319,7 @@ static void *prvIPCPTask(void *pvParameters)
             vRINA_WeakUpUser(pxFlowAllocateRequest);
 #endif
 
-            vRINA_WakeUpFlowRequest(&pxFlowAllocateRequest, eFLOW_BOUND);
+            vRINA_WakeUpFlowRequest(pxFlowAllocateRequest, eFLOW_BOUND);
 
             break;
 
@@ -889,6 +889,7 @@ static void prvIPCPTimerReload(IPCPTimer_t *pxTimer, useconds_t xTimeUS)
     pxTimer->ulReloadTimeUS = xTimeUS;
     prvIPCPTimerStart(pxTimer, xTimeUS);
 }
+
 /*-----------------------------------------------------------*/
 /**
  * @brief Returns whether the IP task is ready.

--- a/components/IPCP/common.c
+++ b/components/IPCP/common.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <string.h>
 #include <limits.h> // For INT_MAX
 

--- a/components/IPCP/include/IPCP_api.h
+++ b/components/IPCP/include/IPCP_api.h
@@ -9,6 +9,7 @@
 #include "efcpStructures.h"
 #include "IPCP_frames.h"
 #include "IPCP_events.h"
+#include "common/rina_ids.h"
 
 /*
  * Send the event eEvent to the IPCP task event queue, using a block time of

--- a/components/IPCP/include/IPCP_events.h
+++ b/components/IPCP/include/IPCP_events.h
@@ -1,6 +1,8 @@
 #ifndef _COMPONENTS_IPCP_EVENTS_H
 #define _COMPONENTS_IPCP_EVENTS_H
 
+#include <stdint.h>
+
 typedef enum RINA_EVENTS
 {
     eNoEvent = -1,
@@ -28,7 +30,13 @@ typedef enum RINA_EVENTS
 typedef struct xRINA_TASK_COMMANDS
 {
     eRINAEvent_t eEventType; /**< The event-type enum */
-    void *pvData;            /**< The data in the event */
+    union {
+        void    *PV;
+        uint32_t UN;
+        int32_t  N;
+        char     C;
+        uint8_t  B;
+    } xData;                 /**< The data in the event */
 } RINAStackEvent_t;
 
 #endif // _COMPONENTS_IPCP_EVENTS_H

--- a/components/IPCP/include/IPCP_instance.h
+++ b/components/IPCP/include/IPCP_instance.h
@@ -5,6 +5,7 @@
 #include "common/rina_ids.h"
 
 #include "rina_common_port.h"
+#include "RINA_API_flows.h"
 
 /* Forward definition of EFCP structures. */
 struct cwq_t;
@@ -108,8 +109,7 @@ struct ipcpInstanceOps_t
     );
 
     bool_t (*flowPrebind)(struct ipcpInstanceData_t *pxData,
-                              // struct ipcpInstance_t *   	pxUserIpcp,
-                              portId_t xPortId);
+                          flowAllocateHandle_t *pxFlowHandle);
 
     bool_t (*flowBindingIpcp)(struct ipcpInstanceData_t *pxUserData,
                                   portId_t xPortId,

--- a/components/IPCP/include/IPCP_normal_api.h
+++ b/components/IPCP/include/IPCP_normal_api.h
@@ -29,7 +29,7 @@ bool_t xNormalFlowAllocationRequest(struct ipcpInstance_t *pxInstanceFrom,
                                     portId_t xShimPortId);
 
 bool_t xNormalFlowPrebind(struct ipcpInstanceData_t *pxData,
-                          portId_t xPortId);
+                          flowAllocateHandle_t *pxFlowHandle);
 
 bool_t xNormalMgmtDuWrite(struct rmt_t *pxRmt, portId_t xPortId, struct du_t *pxDu);
 

--- a/components/IPCP/normalIPCP.c
+++ b/components/IPCP/normalIPCP.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "common/list.h"
+#include "common/rina_ids.h"
 #include "common/rina_name.h"
 #include "portability/port.h"
 
@@ -214,14 +215,14 @@ cepId_t xNormalConnectionCreateRequest(struct efcpContainer_t *pxEfcpc,
         struct ipcpInstance_t *pxIpcp;
 
         xCepId = xEfcpConnectionCreate(pxEfcpc, xSource, xDest,
-                                       xAppPortId, xQosId,
-                                       cep_id_bad(), cep_id_bad(),
+                                       xPortId, xQosId,
+                                       CEP_ID_WRONG, CEP_ID_WRONG,
                                        pxDtpCfg, pxDtcpCfg);
 
         if (!is_cep_id_ok(xCepId))
         {
                 LOGE(TAG_IPCPNORMAL, "Failed EFCP connection creation");
-                return cep_id_bad();
+                return CEP_ID_WRONG;
         }
 
         /*        pxCepEntry = pvPortMalloc(sizeof(*pxCepEntry)); // error

--- a/components/IPCP/normalIPCP.c
+++ b/components/IPCP/normalIPCP.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "RINA_API_flows.h"
 #include "common/list.h"
 #include "common/rina_ids.h"
 #include "common/rina_name.h"
@@ -13,11 +14,11 @@
 #include "configRINA.h"
 #include "IpcManager.h"
 #include "FlowAllocator.h"
-
 #include "BufferManagement.h"
 #include "Ribd.h"
 #include "Ribd_api.h"
 #include "IPCP_api.h"
+#include "RINA_API_flows.h"
 
 extern struct ipcpInstanceData_t *pxIpcpData;
 
@@ -172,12 +173,12 @@ bool_t xNormalDuWrite(struct ipcpInstanceData_t *pxData,
 }*/
 
 bool_t xNormalFlowPrebind(struct ipcpInstanceData_t *pxData,
-                          flowAllocateHandle_t *pxFlowHandle)
+                          flowAllocateHandle_t *pxFlowAllocateHandle)
 {
 
         struct normalFlow_t *pxFlow;
 
-        LOGI(TAG_IPCPNORMAL, "Binding the flow with port id:%d", pxFlowHandle->xPortId);
+        LOGI(TAG_IPCPNORMAL, "Binding the flow with port id:%ud", pxFlowAllocateHandle->xPortId);
 
         if (!pxData)
         {
@@ -192,9 +193,8 @@ bool_t xNormalFlowPrebind(struct ipcpInstanceData_t *pxData,
                 return false;
         }
 
-        pxFlow->xPortId = pxFlowHandle->xPortId;
+        pxFlow->xPortId = pxFlowAllocateHandle->xPortId;
         pxFlow->eState = ePORT_STATE_PENDING;
-        pxFlow->pxFlowHandle = pxFlowHandle;
 
         LOGD(TAG_IPCPNORMAL, "Flow: %p portID: %d portState: %d", pxFlow, pxFlow->xPortId, pxFlow->eState);
         vRsListInitItem(&(pxFlow->xFlowListItem), pxFlow);
@@ -869,6 +869,7 @@ bool_t xNormalConnectionDestroy(cepId_t xSrcCepId)
                 return false;
         }
         */
+
         pxFlow = prvFindFlowCepid(xSrcCepId);
         if (!pxFlow)
         {

--- a/components/IPCP/normalIPCP.c
+++ b/components/IPCP/normalIPCP.c
@@ -88,6 +88,8 @@ static struct ipcpInstance_t *prvNormalIPCPFindInstance(struct ipcpFactoryData_t
 
                 pxListItem = pxRsListGetNext(pxListItem);
         }
+
+        return NULL;
 }
 
 static struct normalFlow_t *prvNormalFindFlow(struct ipcpInstanceData_t *pxData,
@@ -215,7 +217,7 @@ cepId_t xNormalConnectionCreateRequest(struct efcpContainer_t *pxEfcpc,
         struct ipcpInstance_t *pxIpcp;
 
         xCepId = xEfcpConnectionCreate(pxEfcpc, xSource, xDest,
-                                       xPortId, xQosId,
+                                       xAppPortId, xQosId,
                                        CEP_ID_WRONG, CEP_ID_WRONG,
                                        pxDtpCfg, pxDtcpCfg);
 
@@ -309,7 +311,7 @@ bool_t xNormalTest(struct ipcpInstance_t *pxNormalInstance, struct ipcpInstance_
         xBufferSize = strlen(ucStringTest);
         pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(xBufferSize, 1000); // sizeof length DataUser packet.
 
-        LOGI(TAG_IPCPNORMAL, "BufferSize DU:%zu", xBufferSize);
+        LOGI(TAG_IPCPNORMAL, "BufferSize DU: %zu", xBufferSize);
 
         /*Copy the string to the Buffer Network*/
         memcpy(pxNetworkBuffer->pucEthernetBuffer, ucStringTest, xBufferSize);
@@ -469,7 +471,7 @@ bool_t xNormalMgmtDuWrite(struct rmt_t *pxRmt, portId_t xPortId, struct du_t *px
         }
 
         // pxDu->pxCfg = pxData->pxEfcpc->pxConfig;
-        sbytes = xDuLen(pxDu);
+        /* SET BUT NOT USED: sbytes = xDuLen(pxDu); */
 
         if (!xDuEncap(pxDu, PDU_TYPE_MGMT))
         {
@@ -818,7 +820,6 @@ static struct normalFlow_t *prvFindFlowCepid(cepId_t xCepId)
         // shimFlow_t *pxFlowNext;
 
         RsListItem_t *pxListItem;
-        RsListItem_t const *pxListEnd;
 
         if (unRsListLength(&(pxIpcpData->xFlowsList)) == 0)
         {
@@ -859,6 +860,7 @@ bool_t xNormalConnectionDestroy(cepId_t xSrcCepId)
         if (xEfcpConnectionDestroy(pxIpcpData->pxEfcpc, xSrcCepId))
                 LOGE(TAG_EFCP, "Could not destroy EFCP instance: %d", xSrcCepId);
 
+        /* FIXME: The condition below is always TRUE.
         // CRITICAL
         if (!(&pxIpcpData->xFlowsList))
         {
@@ -866,6 +868,7 @@ bool_t xNormalConnectionDestroy(cepId_t xSrcCepId)
                 LOGE(TAG_EFCP, "Could not destroy EFCP instance: %d", xSrcCepId);
                 return false;
         }
+        */
         pxFlow = prvFindFlowCepid(xSrcCepId);
         if (!pxFlow)
         {

--- a/components/IPCP/test/CMakeLists.txt
+++ b/components/IPCP/test/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
     Rmt
     pthread
     portability
-    NetworkInterface
+    NetworkInterface_MQ
     Common
     unity
     rt

--- a/components/IPCP/test/CMakeLists.txt
+++ b/components/IPCP/test/CMakeLists.txt
@@ -23,4 +23,9 @@ else()
     unity
     rt
   )
+
+  add_test(
+    NAME "test_ipcp"
+    COMMAND "./test_ipcp"
+  )
 endif()

--- a/components/IPCP/test/test_ipcp.c
+++ b/components/IPCP/test/test_ipcp.c
@@ -32,7 +32,7 @@ RS_TEST_CASE(IPCPSendEvent, "[ipcp]")
     memcpy(buf->pucEthernetBuffer, txt, sizeof(txt));
 
     ev.eEventType = eNetworkTxEvent;
-    ev.pvData = buf;
+    ev.xData.PV = buf;
 
     /* Send the bogus data */
     TEST_ASSERT(xSendEventStructToIPCPTask(&ev, 100));

--- a/components/IPCP/test/test_ipcp.c
+++ b/components/IPCP/test/test_ipcp.c
@@ -53,6 +53,10 @@ RS_TEST_CASE(IPCPSendEvent, "[ipcp]")
 int main()
 {
     RS_SUITE_BEGIN();
+
+    RINA_IPCPInit();
+    sleep(1);
+
     RS_RUN_TEST(IPCPSendEvent);
     RS_SUITE_END();
 }

--- a/components/NetworkInterface/esp32/NetworkInterface.c
+++ b/components/NetworkInterface/esp32/NetworkInterface.c
@@ -290,9 +290,12 @@ BaseType_t xNetworkInterfaceDisconnect(void)
 esp_err_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 {
 	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	RINAStackEvent_t xRxEvent = {eNetworkRxEvent, NULL};
 	const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS(250);
     struct timespec ts;
+	RINAStackEvent_t xRxEvent = {
+        .eEventType = eNetworkRxEvent,
+        .xData.PV = NULL
+    };
 
 	if (eConsiderFrameForProcessing(buffer) != eProcessBuffer)
 	{
@@ -315,7 +318,7 @@ esp_err_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 
 		/* Copy the packet data. */
 		memcpy(pxNetworkBuffer->pucEthernetBuffer, buffer, len);
-		xRxEvent.pvData = (void *)pxNetworkBuffer;
+		xRxEvent.xData.PV = (void *)pxNetworkBuffer;
 
 		// ESP_LOGE(TAG_RINA, "pucEthernetBuffer and len: %p, %d", pxNetworkBuffer->pucEthernetBuffer, len);
 
@@ -340,7 +343,10 @@ esp_err_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 
 void vNetworkNotifyIFDown()
 {
-	RINAStackEvent_t xRxEvent = {eNetworkDownEvent, NULL};
+	RINAStackEvent_t xRxEvent = {
+        .eEventType = eNetworkDownEvent,
+        .xData.PV = NULL
+    };
 
 	if (xInterfaceState != INTERFACE_DOWN)
 	{

--- a/components/NetworkInterface/linux_tap/NetworkInterface.c
+++ b/components/NetworkInterface/linux_tap/NetworkInterface.c
@@ -1,0 +1,554 @@
+#include <sys/ioctl.h>
+#include <linux/netlink.h>
+#include <linux/if_tun.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+
+#include <pthread.h>
+#include <bits/pthreadtypes.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+
+#include "configSensor.h"
+#include "configRINA.h"
+#include "portability/port.h"
+#include "common/rina_gpha.h"
+
+#include "ARP826_defs.h"
+#include "IPCP_api.h"
+#include "IPCP_events.h"
+#include "BufferManagement.h"
+#include "NetworkInterface.h"
+
+
+struct ReadThreadParams {
+    int nTapFD;
+    int nPipe;
+};
+
+/* The MTU of a TAP device is always 1500. */
+#define TAP_MTU    1500
+
+#define CLONE_DEV  "/dev/net/tun"
+
+/* The 2 following functions are part of the original ESP32
+ * NetworkInterface API, but not in the header file. This keeps them
+ * around but I'm not sure if there is an end goal for them */
+void vNetworkNotifyIFDown();
+
+void vNetworkNotifyIFUp();
+
+/* File descriptor to the tap device we create. */
+static int nTapFD = -1;
+
+/* File descriptor to use to talk to the TAP read thread. */
+static int nTapThreadFD = -1;
+
+/* File descriptor for monitoring the network interface. */
+static int nMonitorFD = -1;
+
+/* Params passed to the TAP read thread. */
+static struct ReadThreadParams xTapReadTreadParams;
+
+/* Reading thread. */
+static pthread_t xReadThread;
+
+static bool_t xIsInterfaceConnected = false;
+
+/* Mutex used to protecte access to nCurrentIffFlags. */
+static pthread_mutex_t xIffDataMutex;
+
+/* Current flags of the interface we use, you need to hold the
+ * "xIffDataMutex" to consult this variable. */
+static int nCurrentIffFlags;
+
+bool_t prvLinuxTapOpen(string_t sTapName, int *pnFD)
+{
+    struct ifreq ifr;
+    int fd, err;
+
+    /* open the clone device */
+    if ((fd = open(CLONE_DEV, O_RDWR)) < 0)
+        return fd;
+
+    memset(&ifr, 0, sizeof(ifr));
+
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;   /* IFF_TUN or IFF_TAP, plus maybe IFF_NO_PI */
+    strncpy(ifr.ifr_name, sTapName, IFNAMSIZ);
+
+    /* Try to create the device */
+    if ((err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0) {
+        close(fd);
+        return false;
+    }
+
+    *pnFD = fd;
+
+    /* this is the special file descriptor that the caller will use to talk
+     * with the virtual interface */
+    return true;
+}
+
+/* Return the flags associated with the device, this also returns a
+ * file description which should be passed to prvLinuxTapSetFlags, or
+ * closed if not needed. */
+bool_t prvLinuxTapGetFlags(string_t sTapName, int *pFD, int *pnFlags)
+{
+    int err, nFD;
+    struct ifreq ifr;
+
+    /* Get the flags that are set */
+    nFD = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (nFD < 0 )
+        return false;
+
+    /* Put the name of the device we want to peek. */
+    strncpy(ifr.ifr_name, sTapName, IFNAMSIZ);
+
+    /* Get the interface flags first. */
+    err = ioctl(nFD, SIOCGIFFLAGS, (void*)&ifr);
+    if (err < 0) {
+        close(nFD);
+        return false;
+    }
+
+    if (pnFlags != NULL)
+        *pnFlags = ifr.ifr_flags;
+
+    if (pFD != NULL)
+        *pFD = nFD;
+    else
+        close(nFD);
+
+    return true;
+}
+
+/* This sets the flags on an interface using the FD opened with
+ * prvLinuxTapGetFlags. Make sure to close it when you're done. */
+bool_t prvLinuxTapSetFlags(string_t sTapName, int nFD, int nFlags)
+{
+    int err;
+    struct ifreq ifr;
+
+    ifr.ifr_flags = nFlags;
+    strncpy(ifr.ifr_name, sTapName, IFNAMSIZ);
+
+    err = ioctl(nFD, SIOCSIFFLAGS, (void*) &ifr);
+    if (err < 0)
+        return err;
+
+    return true;
+}
+
+bool_t prvLinuxTapSetUp(string_t sTapName)
+{
+    int nFD, nFlags;
+    bool bStatus;
+
+    if (!prvLinuxTapGetFlags(sTapName, &nFD, &nFlags))
+        return false;
+
+    nFlags |= (IFF_UP | IFF_RUNNING);
+
+    bStatus = prvLinuxTapSetFlags(sTapName, nFD, nFlags);
+    close(nFD);
+
+    return bStatus;
+}
+
+bool_t prvLinuxTapSetDown(string_t sTapName)
+{
+    int nFD, nFlags;
+    bool bStatus;
+
+    if (!prvLinuxTapGetFlags(sTapName, &nFD, &nFlags))
+        return false;
+
+    nFlags |= ~(IFF_UP | IFF_RUNNING);
+
+    bStatus = prvLinuxTapSetFlags(sTapName, nFD, nFlags);
+    close(nFD);
+
+    return bStatus;
+}
+
+void *prvLinuxTapReadThread(void *pvParams)
+{
+    struct ReadThreadParams *pxParams;
+    uint8_t buffer[TAP_MTU + sizeof(EthernetHeader_t)];
+    struct pollfd pfds[2];
+    int nPoll;
+
+    pxParams = (struct ReadThreadParams *)pvParams;
+
+    /* Prepare the poll descriptors. */
+    pfds[0].fd = pxParams->nTapFD;
+    pfds[0].events = POLLIN | POLLERR;
+    pfds[1].fd = pxParams->nPipe;
+    pfds[1].events = POLLIN | POLLERR;
+
+    LOGI(TAG_WIFI, "Read thread on device %s STARTED", LINUX_TAP_DEVICE);
+
+    while (1) {
+        nPoll = poll(pfds, 2, 0);
+
+        if (pfds[0].revents & POLLIN) {
+            ssize_t count = read(nTapFD, buffer, sizeof(buffer));
+
+            /* Hang ups are not normal here. */
+            if (count < 0 || count == 0) break;
+
+            /* Otherwise, this is an actual packet and send it up the
+               stack. */
+            else xNetworkInterfaceInput(buffer, count, NULL);
+        }
+        else if (pfds[1].revents & POLLIN) {
+            /* The interface is down, just leave. The management
+             * functions will deal with restarting the thread. */
+            LOGD(TAG_WIFI, "Read thread found device %s is DOWN", LINUX_TAP_DEVICE);
+            return NULL;
+        }
+    }
+
+    LOGE(TAG_WIFI, "Read thread on device %s EXITED! (This is not normal!)", LINUX_TAP_DEVICE);
+    return NULL;
+}
+
+bool_t prvLinuxTapCheckFlags(string_t sTapName, int nFlags)
+{
+    int n;
+
+    pthread_mutex_lock(&xIffDataMutex);
+
+    n = (nCurrentIffFlags & nFlags);
+
+    pthread_mutex_unlock(&xIffDataMutex);
+
+    return n > 0;
+}
+
+void prvLinuxTapSaveFlags(int nFlags)
+{
+    pthread_mutex_lock(&xIffDataMutex);
+
+    nCurrentIffFlags = nFlags;
+
+    pthread_mutex_unlock(&xIffDataMutex);
+}
+
+void prvLinuxTapParseNewLinkMsg(struct nlmsghdr *pxNewLinkMsg)
+{
+    struct ifinfomsg *ifi;
+    bool_t isNowUp, isNowDown;
+    stringbuf_t cIfNam[IFNAMSIZ];
+
+    ifi = NLMSG_DATA(pxNewLinkMsg);
+
+    RsAssert(if_indextoname(ifi->ifi_index, cIfNam) != 0);
+
+    /* We obviously only care about the interface we were
+       configured to work with. */
+    if (strcmp(cIfNam, LINUX_TAP_DEVICE) == 0) {
+        pthread_mutex_lock(&xIffDataMutex);
+
+        /* Check if we have a status transition */
+        isNowUp = ((ifi->ifi_flags & IFF_UP) && !(nCurrentIffFlags & IFF_UP));
+        isNowDown = (!(ifi->ifi_flags & IFF_UP) && (nCurrentIffFlags & IFF_UP));
+
+        /* Save the new flags. */
+        nCurrentIffFlags = ifi->ifi_flags;
+
+        pthread_mutex_unlock(&xIffDataMutex);
+
+        if (isNowUp)
+            vNetworkNotifyIFUp();
+        if (isNowDown)
+            vNetworkNotifyIFDown();
+    }
+}
+
+void *prvLinuxTapMonitorThread(void *pNothing)
+{
+    struct nlmsghdr *nlh;
+    int nMonitorFD;
+    char buf[4096 * 2];
+    struct msghdr msg;
+    struct sockaddr_nl xLocalAddr;
+    struct iovec xIov;
+    struct nlmsghdr *pxMsg;
+    ssize_t nRecv = 0;
+
+    msg.msg_name = &xLocalAddr;
+    msg.msg_namelen = sizeof(struct sockaddr_nl);
+    msg.msg_iov = &xIov;
+    msg.msg_iovlen = 1;
+
+    bzero(&xLocalAddr, sizeof(struct sockaddr_nl));
+    xLocalAddr.nl_family = AF_NETLINK;
+    xLocalAddr.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE;
+
+    nMonitorFD = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+
+    if (nMonitorFD < 0) {
+        LOGE(TAG_WIFI, "Failed to open netlink socket");
+        return NULL;
+    }
+
+    if (bind(nMonitorFD, (struct sockaddr *)&xLocalAddr, sizeof(xLocalAddr)) < 0) {
+        LOGE(TAG_WIFI, "Failed to bind() to netlink socket");
+        close(nMonitorFD);
+        return NULL;
+    }
+
+    while (1) {
+        /* Receiving netlink socket data */
+        if (nRecv == 0)
+            nRecv = recv(nMonitorFD, buf, sizeof(buf), 0);
+
+        if (nRecv < 0) {
+            LOGE(TAG_WIFI, "Read error on netlink socket (errno: %d)", errno);
+            goto err;
+        }
+
+        pxMsg = (struct nlmsghdr *)buf;
+
+        for (; NLMSG_OK(pxMsg, nRecv); pxMsg = NLMSG_NEXT(pxMsg, nRecv)) {
+
+            /* This means we are done reading netlink messages */
+            if (pxMsg->nlmsg_type == NLMSG_DONE)
+                break;
+
+            /* We need to parse this specific message. */
+            if (pxMsg->nlmsg_type == RTM_NEWLINK)
+                prvLinuxTapParseNewLinkMsg(pxMsg);
+        }
+    }
+
+    err:
+    LOGE(TAG_WIFI, "Interface monitoring thread EXITED! (This is not a normal situation)");
+    return NULL;
+}
+
+bool_t prvLinuxTapStartReadThread(int *pnTapFD)
+{
+    pthread_attr_t xAttr;
+    bool_t bStatus = true;
+    int nPipe[2];
+
+    /* Setup a pipe so we can communicate with the read thread. */
+    if (pipe(nPipe) < 0)
+        return false;
+
+    /* Make the pipe and the TAP FD non-blocking so that we can use
+       poll(). */
+    if (fcntl(nTapFD, F_SETFD, O_NONBLOCK) < 0 ||
+        fcntl(nPipe[0], F_SETFD, O_NONBLOCK) < 0) {
+        LOGE(TAG_WIFI, "Error setting up FDs for the thread");
+
+        close(nPipe[0]);
+        close(nPipe[1]);
+        return false;
+    }
+
+    nTapThreadFD = nPipe[1];
+
+    xTapReadTreadParams.nPipe = nPipe[0];
+    xTapReadTreadParams.nTapFD = nTapFD;
+
+    pthread_attr_init(&xAttr);
+
+    if (pthread_attr_setdetachstate(&xAttr, PTHREAD_CREATE_DETACHED) != 0)
+        bStatus = false;
+
+    if (pthread_create(&xReadThread, &xAttr, prvLinuxTapReadThread, &xTapReadTreadParams) != 0)
+        bStatus = false;
+
+    pthread_attr_destroy(&xAttr);
+
+    return bStatus;
+}
+
+bool_t prvLinuxTapStartMonitorThread()
+{
+    pthread_attr_t xAttr;
+    bool_t bStatus = false;
+
+    pthread_mutex_init(&xIffDataMutex, NULL);
+
+    pthread_attr_init(&xAttr);
+
+    if (pthread_attr_setdetachstate(&xAttr, PTHREAD_CREATE_DETACHED) != 0)
+        bStatus = false;
+
+    if (pthread_create(&xReadThread, &xAttr, prvLinuxTapMonitorThread, NULL) != 0)
+        bStatus = false;
+
+    pthread_attr_destroy(&xAttr);
+
+    return bStatus;
+}
+
+/* Public interface */
+
+bool_t xNetworkInterfaceInitialise(const MACAddress_t *pxPhyDev)
+{
+#if LINUX_TAP_CREATE == true
+    /* If we're in create mode, return an error if the TAP device
+     * we're asked to create already exists. */
+
+    if (prvLinuxTapGetFlags(LINUX_TAP_DEVICE, NULL, NULL)) {
+        LOGE(TAG_WIFI, "Device %s already exists but we were asked to create it", LINUX_TAP_DEVICE);
+        return false;
+    }
+#endif
+
+    /* Otherwise, just open it. */
+    if (!prvLinuxTapOpen(LINUX_TAP_DEVICE, &nTapFD)) {
+        LOGE(TAG_WIFI, "Failed to open TAP device %s", LINUX_TAP_DEVICE);
+        return false;
+    }
+
+    /* Capture the flags on the device before starting the monitoring
+     * thread. */
+    prvLinuxTapGetFlags(LINUX_TAP_DEVICE, NULL, &nCurrentIffFlags);
+
+    /* Start the thread to monitor the interface. This has to be
+     * always running. */
+    prvLinuxTapStartMonitorThread();
+
+    return true;
+}
+
+bool_t xNetworkInterfaceConnect(void)
+{
+    /* Put UP the device if management is enabled. */
+#if LINUX_TAP_MANAGE == true
+    if (!prvLinuxTapUp(TAP_DEVICE)) {
+        LOGE(TAG_WIFI, "Failed to bring device %s UP", LINUX_TAP_DEVICE);
+        return false;
+    }
+    else LOGI(TAG_WIFI, "Device %s is now UP", LINUX_TAP_DEVICE);
+#endif
+
+    /* Start the read thread only if the device is up. */
+    if (prvLinuxTapCheckFlags(LINUX_TAP_DEVICE, IFF_UP)) {
+
+        /* Spin up the thread that will do the blocking read for packets on
+         * the TAP device. */
+        if (!prvLinuxTapStartReadThread(&nTapFD)) {
+            LOGE(TAG_WIFI, "Failed to spin up read thread on device %s", LINUX_TAP_DEVICE);
+            return false;
+        }
+        else LOGI(TAG_WIFI, "Thread reading on device %s is running", LINUX_TAP_DEVICE);
+    }
+    else
+        LOGW(TAG_WIFI, "Device %s is DOWN, not starting read thread.", LINUX_TAP_DEVICE);
+
+    xIsInterfaceConnected = true;
+
+    return true;
+}
+
+bool_t xNetworkInterfaceDisconnect(void)
+{
+    /* Take down and dispose of the tap device if we were configured
+     * to do so automatically. */
+#if LINUX_TAP_MANAGE == true
+    if (!prvLinuxTapDown(TAP_DEVICE)) {
+        LOGE(TAG_WIFI, "Failed to take device %s DOWN", LINUX_TAP_DEVICE);
+        return false;
+    }
+    else LOGI(TAG_WIFI, "Device %s is now DOWN", LINUX_TAP_DEVICE);
+#endif
+
+    xIsInterfaceConnected = false;
+
+    return true;
+}
+
+bool_t xNetworkInterfaceOutput(NetworkBufferDescriptor_t *const pxNetworkBuffer,
+                               bool_t xReleaseAfterSend)
+{
+    /* Write the packet on the device. */
+    ssize_t nWriteSz;
+    size_t unWriteSzLeft = pxNetworkBuffer->xDataLength;
+    size_t unLastWriteSz = 0;
+
+    if (!prvLinuxTapCheckFlags(LINUX_TAP_DEVICE, IFF_UP)) {
+        LOGE(TAG_WIFI, "Writing %zu bytes on interface %s failed, interface is DOWN",
+             pxNetworkBuffer->xDataLength, LINUX_TAP_DEVICE);
+        return false;
+    }
+
+    do {
+        nWriteSz = write(nTapFD, pxNetworkBuffer->pucEthernetBuffer + unLastWriteSz, unWriteSzLeft);
+
+        if (nWriteSz < 0) {
+            LOGD(TAG_WIFI, "Write error (errno: %d)", errno);
+            return false;
+        }
+
+        unWriteSzLeft -= nWriteSz;
+        unLastWriteSz = nWriteSz;
+    } while (unWriteSzLeft > 0);
+
+    LOGD(TAG_WIFI, "Wrote %zu bytes to the network", pxNetworkBuffer->xDataLength);
+
+    return true;
+}
+
+/* Called by the tap read thread to advertises that an ethernet
+ * frame has arrived. */
+bool_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
+{
+	NetworkBufferDescriptor_t *pxNetworkBuffer;
+	RINAStackEvent_t xRxEvent = {eNetworkRxEvent, NULL};
+
+	if (eConsiderFrameForProcessing(buffer) != eProcessBuffer)
+		return true;
+
+    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(len, 250 * 1000);
+
+	if (pxNetworkBuffer != NULL) {
+		/* Set the packet size, in case a larger buffer was returned. */
+		pxNetworkBuffer->xEthernetDataLength = len;
+
+		/* Copy the packet data. */
+		memcpy(pxNetworkBuffer->pucEthernetBuffer, buffer, len);
+		xRxEvent.pvData = (void *)pxNetworkBuffer;
+
+		if (!xSendEventStructToIPCPTask(&xRxEvent, 250 * 1000)) {
+			LOGE(TAG_WIFI, "Failed to enqueue packet to network stack %p, len %d", buffer, len);
+			vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+			return false;
+		}
+
+		return true;
+	}
+	else {
+        LOGE(TAG_WIFI, "Failed to get buffer descriptor");
+        vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+        return false;
+    }
+}
+
+void vNetworkNotifyIFDown()
+{
+    char n = 99; /* Random crap to wake up the read thread. */
+
+    LOGW(TAG_WIFI, "Interface %s is now DOWN", LINUX_TAP_DEVICE);
+
+    if (xIsInterfaceConnected)
+        write(nTapThreadFD, &n, 1);
+}
+
+void vNetworkNotifyIFUp()
+{
+    LOGW(TAG_WIFI, "Interface %s is now UP", LINUX_TAP_DEVICE);
+
+    if (xIsInterfaceConnected)
+        prvLinuxTapStartReadThread(&nTapFD);
+}

--- a/components/NetworkInterface/linux_tap/NetworkInterface.c
+++ b/components/NetworkInterface/linux_tap/NetworkInterface.c
@@ -505,7 +505,10 @@ bool_t xNetworkInterfaceOutput(NetworkBufferDescriptor_t *const pxNetworkBuffer,
 bool_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 {
 	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	RINAStackEvent_t xRxEvent = {eNetworkRxEvent, NULL};
+	RINAStackEvent_t xRxEvent = {
+        .eEventType = eNetworkRxEvent,
+        .xData.PV = NULL
+    };
 
 	if (eConsiderFrameForProcessing(buffer) != eProcessBuffer)
 		return true;
@@ -518,7 +521,7 @@ bool_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 
 		/* Copy the packet data. */
 		memcpy(pxNetworkBuffer->pucEthernetBuffer, buffer, len);
-		xRxEvent.pvData = (void *)pxNetworkBuffer;
+		xRxEvent.xData.PV = (void *)pxNetworkBuffer;
 
 		if (!xSendEventStructToIPCPTask(&xRxEvent, 250 * 1000)) {
 			LOGE(TAG_WIFI, "Failed to enqueue packet to network stack %p, len %d", buffer, len);

--- a/components/NetworkInterface/mq/NetworkInterface.c
+++ b/components/NetworkInterface/mq/NetworkInterface.c
@@ -299,7 +299,7 @@ bool_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 
 		/* Copy the packet data. */
 		memcpy(pxNetworkBuffer->pucEthernetBuffer, buffer, len);
-		xRxEvent.pvData = (void *)pxNetworkBuffer;
+		xRxEvent.xData.PV = (void *)pxNetworkBuffer;
 
 		if (xSendEventStructToIPCPTask(&xRxEvent, 0) == false)
 		{

--- a/components/NetworkInterface/mq/NetworkInterface.c
+++ b/components/NetworkInterface/mq/NetworkInterface.c
@@ -134,7 +134,7 @@ void xMqNetworkInterfaceOutputDiscard() {
 
 bool_t xMqNetworkInterfaceWriteInput(string_t data, size_t sz)
 {
-    RsAssert(sz >= mqInitAttr.mq_msgsize);
+    RsAssert((int)sz >= mqInitAttr.mq_msgsize);
 
     if (mq_send(mqIn, data, sz, 0) < 0)
         return false;
@@ -274,12 +274,12 @@ bool_t xNetworkInterfaceOutput(NetworkBufferDescriptor_t *const pxNetworkBuffer,
 {
     if (mq_send(mqOut, (const char *)pxNetworkBuffer->pucEthernetBuffer,
                 pxNetworkBuffer->xDataLength, 0) != 0) {
-        LOGE(TAG_WIFI, "Error writing %u bytes to network interface (errno: %d)",
+        LOGE(TAG_WIFI, "Error writing %zu bytes to network interface (errno: %d)",
              pxNetworkBuffer->xDataLength, errno);
         return false;
     }
 
-    LOGI(TAG_WIFI, "Wrote %u bytes to network interface", pxNetworkBuffer->xDataLength);
+    LOGI(TAG_WIFI, "Wrote %zu bytes to network interface", pxNetworkBuffer->xDataLength);
 
     return true;
 }
@@ -287,9 +287,10 @@ bool_t xNetworkInterfaceOutput(NetworkBufferDescriptor_t *const pxNetworkBuffer,
 bool_t xNetworkInterfaceInput(void *buffer, uint16_t len, void *eb)
 {
 	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	RINAStackEvent_t xRxEvent = {eNetworkRxEvent, NULL};
+	RINAStackEvent_t xRxEvent;
 
 	pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(len, 0);
+    xRxEvent.eEventType = eNetworkRxEvent;
 
 	if (pxNetworkBuffer != NULL)
 	{

--- a/components/NetworkInterface/test/CMakeLists.txt
+++ b/components/NetworkInterface/test/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
   )
   target_link_libraries(test_networkinterface_io
     mock_IPCP
-    NetworkInterface
+    NetworkInterface_MQ
     Common
     BufferManagement
     portability

--- a/components/Portability/freertos_idf/include/freertos_rsdefs.h
+++ b/components/Portability/freertos_idf/include/freertos_rsdefs.h
@@ -12,6 +12,9 @@ typedef BaseType_t num_t;
 typedef char* string_t;
 #define PORT_HAS_STRING_T
 
+typedef char  stringbuf_t;
+#define PORT_HAS_STRINGBUF_T
+
 typedef uint8_t* buffer_t;
 #define PORT_HAS_BUFFER_T
 

--- a/components/Portability/include/portability/rsdefs.h
+++ b/components/Portability/include/portability/rsdefs.h
@@ -15,6 +15,10 @@
 #error Port undefined: string_t
 #endif
 
+#ifndef PORT_HAS_STRINGBUF_T
+#error Port undefined: stringbuf_t
+#endif
+
 #ifndef PORT_HAS_BUFFER_T
 #error Port undefined: buffer_t
 #endif

--- a/components/Portability/linux/include/linux_rsdefs.h
+++ b/components/Portability/linux/include/linux_rsdefs.h
@@ -12,6 +12,9 @@ typedef int  num_t;
 typedef char* string_t;
 #define PORT_HAS_STRING_T
 
+typedef char  stringbuf_t;
+#define PORT_HAS_STRINGBUF_T
+
 typedef uint8_t* buffer_t;
 #define PORT_HAS_BUFFER_T
 

--- a/components/Portability/posix/posix_rsqueue.c
+++ b/components/Portability/posix/posix_rsqueue.c
@@ -131,8 +131,12 @@ bool_t xRsQueueReceive(RsQueue_t *pQueue, void *pvBuffer, const size_t unBufferS
     if (!rstime_waitusec(&ts, xTimeOutUS))
         return false;
 
-    if (mq_timedreceive(pQueue->xQueue, pvBuffer, unBufferSz, 0, &ts) < 0)
+    if (mq_timedreceive(pQueue->xQueue, pvBuffer, unBufferSz, 0, &ts) < 0) {
+        if (errno != ETIMEDOUT)
+            LOGE(TAG, "mq_timedreceive error: %d", errno);
+
         return false;
+    }
 
     return true;
 }

--- a/components/Portability/test/test_queues.c
+++ b/components/Portability/test/test_queues.c
@@ -50,7 +50,7 @@ RS_TEST_CASE(AddRead, "[queues]")
 RS_TEST_CASE(SizeErrors, "[queues]")
 {
     RsQueue_t *q;
-    uint32_t i1 = 1, i2 = 2;
+    uint32_t i1 = 1;
     uint32_t j1;
 
     RS_TEST_CASE_BEGIN(test_queues);

--- a/components/RINA_API/RINA_API.c
+++ b/components/RINA_API/RINA_API.c
@@ -19,6 +19,7 @@
 
 #include "BufferManagement.h"
 #include "RINA_API_flows.h"
+#include "common/list.h"
 #include "configSensor.h"
 #include "rina_buffers.h"
 #include "rina_common_port.h"
@@ -459,7 +460,7 @@ bool_t RINA_close(portId_t xAppPortId)
 
     RINAStackEvent_t xDeallocateEvent;
     xDeallocateEvent.eEventType = eFlowDeallocateEvent;
-    xDeallocateEvent.pvData = xAppPortId;
+    xDeallocateEvent.pvData = (void *)(long)xAppPortId;
 
     if (!is_port_id_ok(xAppPortId))
         xResult = false;

--- a/components/RINA_API/RINA_API.c
+++ b/components/RINA_API/RINA_API.c
@@ -61,7 +61,10 @@ struct appRegistration_t *RINA_application_register(string_t pcNameDif,
 {
     name_t *xDn, *xAppn, *xDan;
     registerApplicationHandle_t *xRegAppRequest;
-    RINAStackEvent_t xStackAppRegistrationEvent = {eStackAppRegistrationEvent, NULL};
+    RINAStackEvent_t xStackAppRegistrationEvent = {
+        .eEventType = eStackAppRegistrationEvent,
+        .xData.PV = NULL
+    };
 
     xRegAppRequest = pvRsMemAlloc(sizeof(registerApplicationHandle_t));
     if (!xRegAppRequest) {
@@ -107,7 +110,7 @@ struct appRegistration_t *RINA_application_register(string_t pcNameDif,
     xRegAppRequest->pxDifName = xDn;
     xRegAppRequest->pxDafName = xDan;
 
-    xStackAppRegistrationEvent.pvData = xRegAppRequest;
+    xStackAppRegistrationEvent.xData.PV = xRegAppRequest;
 
     if (xSendEventStructToIPCPTask(&xStackAppRegistrationEvent, (TickType_t)0U) == pdPASS)
         {
@@ -128,7 +131,7 @@ bool_t xRINA_bind(flowAllocateHandle_t *pxFlowRequest)
     }
 
     xBindEvent.eEventType = eFlowBindEvent;
-    xBindEvent.pvData = (void *)pxFlowRequest;
+    xBindEvent.xData.PV = (void *)pxFlowRequest;
 
     if (xSendEventStructToIPCPTask(&xBindEvent, 0) == false)
         /* Failed to wake-up the IPCP-task, no use to wait for it */
@@ -292,7 +295,10 @@ bool_t RINA_flowStatus(portId_t xAppPortId)
 bool_t prvConnect(flowAllocateHandle_t *pxFlowAllocateRequest)
 {
     bool_t xResult = 0;
-    RINAStackEvent_t xStackFlowAllocateEvent = {eStackFlowAllocateEvent, NULL};
+    RINAStackEvent_t xStackFlowAllocateEvent = {
+        .eEventType = eStackFlowAllocateEvent,
+        .xData.PV = NULL
+    };
 
     if (pxFlowAllocateRequest == NULL) {
         LOGE(TAG_RINA, "No flow request passed");
@@ -405,7 +411,10 @@ size_t RINA_flow_write(portId_t xPortId, void *pvBuffer, size_t uxTotalDataLengt
     void *pvCopyDest;
     struct RsTimeOut xTimeOut;
     useconds_t xTimeToWait, xTimeDiff;
-    RINAStackEvent_t xStackTxEvent = {eStackTxEvent, NULL};
+    RINAStackEvent_t xStackTxEvent = {
+        .eEventType = eStackTxEvent,
+        .xData.PV = NULL
+    };
 
     /* Check that DataLength is not longer than MAX_SDU_SIZE. We
      * don't know yet WHAT to do if this is not true so make sure we
@@ -437,7 +446,7 @@ size_t RINA_flow_write(portId_t xPortId, void *pvBuffer, size_t uxTotalDataLengt
         pxNetworkBuffer->xDataLength = uxTotalDataLength;
         pxNetworkBuffer->ulBoundPort = xPortId;
 
-        xStackTxEvent.pvData = pxNetworkBuffer;
+        xStackTxEvent.xData.PV = pxNetworkBuffer;
 
         if (xSendEventStructToIPCPTask(&xStackTxEvent, xTimeToWait))
             return uxTotalDataLength;
@@ -460,7 +469,7 @@ bool_t RINA_close(portId_t xAppPortId)
 
     RINAStackEvent_t xDeallocateEvent;
     xDeallocateEvent.eEventType = eFlowDeallocateEvent;
-    xDeallocateEvent.pvData = (void *)(long)xAppPortId;
+    xDeallocateEvent.xData.UN = xAppPortId;
 
     if (!is_port_id_ok(xAppPortId))
         xResult = false;

--- a/components/RINA_API/include/RINA_API_flows.h
+++ b/components/RINA_API/include/RINA_API_flows.h
@@ -1,6 +1,7 @@
 #ifndef _COMPONENTS_RINA_API_FLOWS_H
 #define _COMPONENTS_RINA_API_FLOWS_H
 
+#include "common/list.h"
 #include "common/rina_name.h"
 #include "common/rina_ids.h"
 #include "common/list.h"

--- a/components/Ribd/Ribd.c
+++ b/components/Ribd/Ribd.c
@@ -202,7 +202,7 @@ messageCdap_t *prvRibdFillDecodeMessage(rina_messages_CDAPMessage message)
     pxMessageCdap->pxSourceInfo = pxSourceInfo;
     pxMessageCdap->pxAuthPolicy = pxAuthPolicy;
 
-    pxMessageCdap->eOpCode = message.opCode;
+    pxMessageCdap->eOpCode = (opCode_t)message.opCode;
     pxMessageCdap->version = message.version;
     pxMessageCdap->invokeID = message.invokeID;
     pxMessageCdap->result = message.result;
@@ -307,7 +307,7 @@ rina_messages_CDAPMessage prvRibdSerToRinaMessage(messageCdap_t *pxMessageCdap)
     message.version = pxMessageCdap->version;
     message.has_version = true;
 
-    message.opCode = pxMessageCdap->eOpCode;
+    message.opCode = (rina_messages_opCode_t)pxMessageCdap->eOpCode;
 
     message.invokeID = pxMessageCdap->invokeID;
     message.has_invokeID = true;
@@ -417,7 +417,6 @@ NetworkBufferDescriptor_t *prvRibdEncodeCDAP(messageCdap_t *pxMessageCdap)
     bool_t status;
     uint8_t *pucBuffer[128];
     size_t xMessageLength;
-    struct timespec ts;
 
     /*Create a stream that will write to the buffer*/
     pb_ostream_t stream = pb_ostream_from_buffer((pb_byte_t *)pucBuffer, sizeof(pucBuffer));
@@ -428,7 +427,7 @@ NetworkBufferDescriptor_t *prvRibdEncodeCDAP(messageCdap_t *pxMessageCdap)
     message.version = pxMessageCdap->version;
     message.has_version = true;
 
-    message.opCode = pxMessageCdap->eOpCode;
+    message.opCode = (rina_messages_opCode_t)pxMessageCdap->eOpCode;
 
     message.invokeID = pxMessageCdap->invokeID;
     message.has_invokeID = true;
@@ -539,7 +538,7 @@ NetworkBufferDescriptor_t *prvRibdEncodeCDAP(messageCdap_t *pxMessageCdap)
         return NULL;
     }
 
-    LOGI(TAG_RIB, "Message CDAP with length: %u encoded sucessfully ", xMessageLength);
+    LOGI(TAG_RIB, "Message CDAP with length: %zu encoded sucessfully ", xMessageLength);
 
     /*Request a Network Buffer according to Message Length*/
     NetworkBufferDescriptor_t *pxNetworkBuffer;
@@ -581,12 +580,11 @@ messageCdap_t *prvRibdDecodeCDAP(uint8_t *pucBuffer, size_t xMessageLength)
 appConnection_t *pxRibdFindAppConnection(portId_t xPortId)
 {
     LOGI(TAG_RIB, "Looking for an active connection in the port id %d", xPortId);
-    bool_t x = 0;
+    num_t x = 0;
     appConnection_t *pxAppConnection;
     pxAppConnection = pvRsMemAlloc(sizeof(*pxAppConnection));
 
     for (x = 0; x < APP_CONNECTION_TABLE_SIZE; x++)
-
     {
         if (xAppConnectionTable[x].xValid == true)
         {
@@ -750,7 +748,7 @@ bool_t xRibdConnectToIpcp(struct ipcpInstanceData_t *pxIpcpData, name_t *pxSourc
     messageCdap_t *pxMessageEncode = prvRibMessageCdapInit();
 
     /*Fill the Message to be encoded in the connection*/
-    pxMessageEncode->eOpCode = rina_messages_opCode_t_M_CONNECT;
+    pxMessageEncode->eOpCode = (opCode_t)rina_messages_opCode_t_M_CONNECT;
     pxMessageEncode->pxDestinationInfo->pcEntityName = strdup(pxDestInfo->pcEntityName);
     pxMessageEncode->pxDestinationInfo->pcProcessInstance = strdup(pxDestInfo->pcProcessInstance);
     pxMessageEncode->pxDestinationInfo->pcProcessName = strdup(pxDestInfo->pcProcessName);
@@ -791,7 +789,7 @@ void vRibdPrintCdapMessage(messageCdap_t *pxDecodeCdap)
     LOGE(TAG_RIB, "DECODE");
     LOGE(TAG_RIB, "opCode: %s", opcodeNamesTable[pxDecodeCdap->eOpCode]);
     LOGE(TAG_RIB, "Invoke Id: %d ", pxDecodeCdap->invokeID);
-    LOGE(TAG_RIB, "Version: %lld", pxDecodeCdap->version);
+    LOGE(TAG_RIB, "Version: %jd", pxDecodeCdap->version);
     if (pxDecodeCdap->pxAuthPolicy->pcName != NULL)
     {
         LOGE(TAG_RIB, "AuthPolicy Name: %s", pxDecodeCdap->pxAuthPolicy->pcName);
@@ -1092,6 +1090,7 @@ bool_t xRibdSendResponse(string_t pcObjClass, string_t pcObjName, long objInst,
     case M_START_R:
         pxMsgCdap = prvRibdFillEnrollMsgStart(pcObjClass, pcObjName, objInst, eOpCode, pxObjVal,
                                               result, pcResultReason, invokeId);
+        break;
     case M_STOP_R:
         pxMsgCdap = prvRibdFillEnrollMsgStop(pcObjClass, pcObjName, objInst, eOpCode, pxObjVal,
                                              result, pcResultReason, invokeId);

--- a/components/Ribd/include/Ribd.h
+++ b/components/Ribd/include/Ribd.h
@@ -83,7 +83,7 @@ typedef struct xMESSAGE_CDAP
     name_t *pxSourceInfo;
 
     /*Version*/
-    int64_t version;
+    intmax_t version;
 
     /*Authentication Policy*/
     authPolicy_t *pxAuthPolicy;

--- a/components/Ribd/test/CMakeLists.txt
+++ b/components/Ribd/test/CMakeLists.txt
@@ -21,6 +21,7 @@ else()
     pthread
     Common
     portability
+    NetworkInterface_MQ
   )
 
   add_executable(test_rib "${CMAKE_CURRENT_LIST_DIR}/test_rib.c")

--- a/components/Rmt/Rmt.c
+++ b/components/Rmt/Rmt.c
@@ -165,7 +165,7 @@ bool_t xRmtPduIsAddressedToMe(struct rmt_t *pxRmt, address_t xAddress);
 bool_t xRmtPduIsAddressedToMe(struct rmt_t *pxRmt, address_t xAddress)
 {
 	rmtAddress_t *pxAddr;
-	RsListItem_t *pxListItem, *pxNext;
+	RsListItem_t *pxListItem;
 
 	pxAddr = pvRsMemAlloc(sizeof(*pxAddr));
 
@@ -388,7 +388,6 @@ static bool_t xRmtN1PortWriteDu(struct rmt_t *pxRmt,
 {
 
 	bool_t ret;
-	ssize_t bytes = pxDu->pxNetworkBuffer->xDataLength;
 
 	LOGI(TAG_RMT, "Gonna send SDU to port-id %d", pxN1Port->xPortId);
 	ret = pxN1Port->pxN1Ipcp->pxOps->duWrite(pxN1Port->pxN1Ipcp->pxData, pxN1Port->xPortId, pxDu, false);
@@ -529,8 +528,6 @@ bool_t xRmtSendPortId(struct rmt_t *pxRmtInstance,
 bool_t xRmtSend(struct rmt_t *pxRmtInstance,
 				struct du_t *pxDu)
 {
-	int i;
-
 	if (!pxRmtInstance || !pxDu || !xPciIsOk(pxDu->pxPci))
 	{
 		LOGE(TAG_RMT, "Bogus input parameters passed");
@@ -607,14 +604,20 @@ struct rmt_t *pxRmtCreate(struct efcpContainer_t *pxEfcpc)
 		rmt_destroy(tmp);
 		return NULL;
 	}*/
-	pxRmtTmp->pxN1Port = pxPortN1;
+
+    /* FIXME: This assignment makes no sense and the compile complains
+       about it. */
+	/* pxRmtTmp->pxN1Port = pxPortN1; */
+
 	// tmp->n1_ports = n1pmap_create(&tmp->robj);
+#if 0
 	if (!pxRmtTmp->pxN1Port)
 	{
 		LOGI(TAG_RMT, "Failed to create N-1 ports map");
 		// rmt_destroy(tmp);
 		return NULL;
 	}
+#endif
 
 	/*if (pff_cache_init(&tmp->cache)) {
 		LOG_ERR("Failed to init pff cache");

--- a/components/Rmt/du.c
+++ b/components/Rmt/du.c
@@ -38,7 +38,6 @@ bool_t xDuDecap(struct du_t *pxDu)
 	NetworkBufferDescriptor_t *pxNewBuffer;
 	uint8_t *pucData;
 	size_t uxBufferSize;
-	struct timespec ts;
 
 	/* Extract PCI from buffer*/
 	pxPciTmp = vCastPointerTo_pci_t(pxDu->pxNetworkBuffer->pucRinaBuffer);
@@ -119,8 +118,7 @@ bool_t xDuEncap(struct du_t *pxDu, pduType_t xType)
 	NetworkBufferDescriptor_t *pxNewBuffer;
 	uint8_t *pucDataPtr;
 	size_t xBufferSize;
-	pci_t *pxPciTmp;
-	struct timespec ts;
+	pci_t * pxPciTmp;
 
 	uxPciLen = (size_t)(14); /* PCI defined static for this initial stage = 14Bytes*/
 

--- a/components/ShimIPCP/ShimIPCP.c
+++ b/components/ShimIPCP/ShimIPCP.c
@@ -330,7 +330,7 @@ bool_t xShimFlowAllocateResponse(struct ipcpInstanceData_t *pxShimInstanceData,
 	if (pxFlow->ePortIdState == eALLOCATED)
 	{
 		LOGI(TAG_SHIM, "Flow with id:%d was allocated", pxFlow->xPortId);
-		xEnrollEvent.pvData = xPortId;
+		xEnrollEvent.pvData = (void *)(uintptr_t)xPortId;
 		xSendEventStructToIPCPTask(&xEnrollEvent, 250 * 1000);
 	}
 
@@ -535,15 +535,10 @@ bool_t xShimApplicationUnregister(struct ipcpInstanceData_t *pxData, const name_
 
 /***************** **************************/
 
-int string_len(const string_t s)
-{
-	return strlen(s);
-}
-
 string_t pcShimNameToString(const name_t *n)
 {
 	string_t tmp;
-	size_t size;
+	ssize_t size;
 	const string_t none = "";
 	size_t none_len = strlen(none);
 
@@ -552,16 +547,16 @@ string_t pcShimNameToString(const name_t *n)
 
 	size = 0;
 
-	size += (n->pcProcessName ? string_len(n->pcProcessName) : none_len);
+	size += (n->pcProcessName ? strlen(n->pcProcessName) : none_len);
 	size += strlen(DELIMITER);
 
-	size += (n->pcProcessInstance ? string_len(n->pcProcessInstance) : none_len);
+	size += (n->pcProcessInstance ? strlen(n->pcProcessInstance) : none_len);
 	size += strlen(DELIMITER);
 
-	size += (n->pcEntityName ? string_len(n->pcEntityName) : none_len);
+	size += (n->pcEntityName ? strlen(n->pcEntityName) : none_len);
 	size += strlen(DELIMITER);
 
-	size += (n->pcEntityInstance ? string_len(n->pcEntityInstance) : none_len);
+	size += (n->pcEntityInstance ? strlen(n->pcEntityInstance) : none_len);
 	size += strlen(DELIMITER);
 
 	tmp = pvRsMemAlloc(size);
@@ -700,9 +695,9 @@ int QueueDestroy(rfifo_t *f,
 
 	vRsQueueDelete(f->xQueue);
 
-	vRsMemFree(f);
-
 	LOGI(TAG_SHIM, "FIFO %pK destroyed successfully", f);
+
+	vRsMemFree(f);
 
 	return 0;
 }
@@ -770,7 +765,7 @@ bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_
 
 	if (uxLength > MTU)
 	{
-		LOGE(TAG_SHIM, "SDU too large (%u), dropping", uxLength);
+		LOGE(TAG_SHIM, "SDU too large (%zu), dropping", uxLength);
 		xDuDestroy(pxDu);
 		return false;
 	}

--- a/components/ShimIPCP/ShimIPCP.c
+++ b/components/ShimIPCP/ShimIPCP.c
@@ -262,7 +262,10 @@ bool_t xShimFlowAllocateResponse(struct ipcpInstanceData_t *pxShimInstanceData,
 								 portId_t xPortId)
 
 {
-	RINAStackEvent_t xEnrollEvent = {eShimFlowAllocatedEvent, NULL};
+	RINAStackEvent_t xEnrollEvent = {
+        .eEventType = eShimFlowAllocatedEvent,
+        .xData.PV = NULL
+    };
 	shimFlow_t *pxFlow;
 	struct ipcpInstance_t *pxShimIpcp;
 
@@ -330,7 +333,7 @@ bool_t xShimFlowAllocateResponse(struct ipcpInstanceData_t *pxShimInstanceData,
 	if (pxFlow->ePortIdState == eALLOCATED)
 	{
 		LOGI(TAG_SHIM, "Flow with id:%d was allocated", pxFlow->xPortId);
-		xEnrollEvent.pvData = (void *)(uintptr_t)xPortId;
+		xEnrollEvent.xData.UN = xPortId;
 		xSendEventStructToIPCPTask(&xEnrollEvent, 250 * 1000);
 	}
 
@@ -741,7 +744,6 @@ static bool_t prvShimFlowDestroy(struct ipcpInstanceData_t *xData, shimFlow_t *x
 
 bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_t *pxDu, bool_t uxBlocking)
 {
-
 	shimFlow_t *pxFlow;
 	NetworkBufferDescriptor_t *pxNetworkBuffer;
 	EthernetHeader_t *pxEthernetHeader;
@@ -749,7 +751,10 @@ bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_
 	gha_t *pxDestHw;
 	size_t uxHeadLen, uxLength;
 	struct timespec ts;
-	RINAStackEvent_t xTxEvent = {eNetworkTxEvent, NULL};
+	RINAStackEvent_t xTxEvent = {
+        .eEventType = eNetworkTxEvent,
+        .xData.PV = NULL
+    };
 	unsigned char *pucArpPtr;
 
 	LOGI(TAG_SHIM, "SDU write received");
@@ -843,7 +848,7 @@ bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_
 
 	/* ReleaseBuffer, no need anymore that why pdTRUE here */
 
-	xTxEvent.pvData = (void *)pxNetworkBuffer;
+	xTxEvent.xData.PV = (void *)pxNetworkBuffer;
 
 	if (xSendEventStructToIPCPTask(&xTxEvent, 250 * 1000) == false)
 	{
@@ -992,14 +997,17 @@ struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId)
 }
 
 /*Check this logic.*/
-bool_t xShimWiFiInit(ipcpInstance_t *pxShimWiFiInstance)
+bool_t xShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance)
 {
 	/*xShimWiFiInit is going to init the  WiFi drivers and associate to the AP.
 	 * Update de MacAddress variable depending on the WiFi drivers. Sent this variable
 	 * as event data to be used when the shimWiFi D(F will be created.*/
 
 	LOGI(TAG_SHIM, "Wifi shim initialization");
-	RINAStackEvent_t xEnrollEvent = {eShimEnrolledEvent, NULL};
+	RINAStackEvent_t xEnrollEvent = {
+        .eEventType = eShimEnrolledEvent,
+        .xData.PV = NULL
+    };
 
 	if (!xShimEnrollToDIF(pxShimWiFiInstance->pxData->pxPhyDev)) {
 		LOGE(TAG_SHIM, "Wifi shim instance can't enroll to DIF");
@@ -1007,7 +1015,7 @@ bool_t xShimWiFiInit(ipcpInstance_t *pxShimWiFiInstance)
     }
 	else
 	{
-		xEnrollEvent.pvData = (void *)(pxShimWiFiInstance->pxData->pxPhyDev);
+		xEnrollEvent.xData.PV = (void *)(pxShimWiFiInstance->pxData->pxPhyDev);
 		xSendEventStructToIPCPTask(&xEnrollEvent, 50 * 1000);
         return true;
 	}

--- a/components/ShimIPCP/ShimIPCP.c
+++ b/components/ShimIPCP/ShimIPCP.c
@@ -992,7 +992,7 @@ struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId)
 }
 
 /*Check this logic.*/
-void vShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance)
+bool_t xShimWiFiInit(ipcpInstance_t *pxShimWiFiInstance)
 {
 	/*xShimWiFiInit is going to init the  WiFi drivers and associate to the AP.
 	 * Update de MacAddress variable depending on the WiFi drivers. Sent this variable
@@ -1001,11 +1001,14 @@ void vShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance)
 	LOGI(TAG_SHIM, "Wifi shim initialization");
 	RINAStackEvent_t xEnrollEvent = {eShimEnrolledEvent, NULL};
 
-	if (!xShimEnrollToDIF(pxShimWiFiInstance->pxData->pxPhyDev))
+	if (!xShimEnrollToDIF(pxShimWiFiInstance->pxData->pxPhyDev)) {
 		LOGE(TAG_SHIM, "Wifi shim instance can't enroll to DIF");
+        return false;
+    }
 	else
 	{
 		xEnrollEvent.pvData = (void *)(pxShimWiFiInstance->pxData->pxPhyDev);
 		xSendEventStructToIPCPTask(&xEnrollEvent, 50 * 1000);
+        return true;
 	}
 }

--- a/components/ShimIPCP/include/ShimIPCP.h
+++ b/components/ShimIPCP/include/ShimIPCP.h
@@ -118,7 +118,7 @@ void vShimWrite(void);
  * */
 void vShimRead(void);
 
-void vShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance);
+bool_t xShimWiFiInit(ipcpInstance_t *pxShimWiFiInstance);
 
 struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId);
 

--- a/components/ShimIPCP/include/ShimIPCP.h
+++ b/components/ShimIPCP/include/ShimIPCP.h
@@ -18,8 +18,6 @@
 #include "du.h"
 #include "rina_common_port.h"
 
-typedef int32_t portId_t;
-
 /* Flow states */
 typedef enum xFLOW_STATES
 

--- a/components/ShimIPCP/include/ShimIPCP.h
+++ b/components/ShimIPCP/include/ShimIPCP.h
@@ -118,7 +118,7 @@ void vShimWrite(void);
  * */
 void vShimRead(void);
 
-bool_t xShimWiFiInit(ipcpInstance_t *pxShimWiFiInstance);
+bool_t xShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance);
 
 struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId);
 

--- a/components/configRINA/include/configRINA.h
+++ b/components/configRINA/include/configRINA.h
@@ -52,4 +52,19 @@
 #define DTP_INITIAL_A_TIMER (300)
 #define DTP_DTCP_PRESENT false
 
+	#define DTP_INITIAL_A_TIMER						( 300 )
+	#define DTP_DTCP_PRESENT						false
+
+/* Linux NetworkInterface options. */
+
+/* Decides if the TAP NetworkInterface will create the tap device itself. */
+#define LINUX_TAP_CREATE       false
+
+/* Decides if the TAP NetworkInterface will put UP, or DOWN, the
+ * virtual device. */
+#define LINUX_TAP_MANAGE       false
+
+/* */
+#define LINUX_TAP_DEVICE       "rina00"
+
 #endif

--- a/components/configRINA/include/configRINA.h
+++ b/components/configRINA/include/configRINA.h
@@ -52,9 +52,6 @@
 #define DTP_INITIAL_A_TIMER (300)
 #define DTP_DTCP_PRESENT false
 
-	#define DTP_INITIAL_A_TIMER						( 300 )
-	#define DTP_DTCP_PRESENT						false
-
 /* Linux NetworkInterface options. */
 
 /* Decides if the TAP NetworkInterface will create the tap device itself. */

--- a/components/configSensor/include/configSensor.h
+++ b/components/configSensor/include/configSensor.h
@@ -20,8 +20,8 @@
 #define DECL_CAST_PTR_FUNC_FOR_TYPE(TYPE) TYPE *vCastPointerTo_##TYPE(void *pvArgument)
 #define DECL_CAST_CONST_PTR_FUNC_FOR_TYPE(TYPE) const TYPE *vCastConstPointerTo_##TYPE(const void *pvArgument)
 
-#define ETH_P_RINA 0xD1F0
-#define ETH_P_ARP 0x4305
+	#define ETH_P_RINA      				0xD1F0
+	#define ETH_P_RINA_ARP						0x4305
 
 /********* Define BLE Parameters ****************/
 

--- a/components_mocks/mock_EFCP/efcp.c
+++ b/components_mocks/mock_EFCP/efcp.c
@@ -1,4 +1,5 @@
 #include "common/rina_ids.h"
+#include "efcpStructures.h"
 #include "du.h"
 #include "efcpStructures.h"
 

--- a/components_mocks/mock_EFCP/efcp.c
+++ b/components_mocks/mock_EFCP/efcp.c
@@ -1,5 +1,6 @@
 #include "common/rina_ids.h"
 #include "du.h"
+#include "efcpStructures.h"
 
 #ifdef ESP_PLATFORM
 bool_t mock_EFCP_xEfcpEnqueue(struct efcp_t * pxEfcp, portId_t xPort, struct du_t * pxDu)

--- a/components_mocks/mock_FlowAllocator/flowAllocator.c
+++ b/components_mocks/mock_FlowAllocator/flowAllocator.c
@@ -8,12 +8,12 @@
 void mock_FlowAllocator_vFlowAllocatorFlowRequest(struct efcpContainer_t *pxEfcpc,
                                                   portId_t xPortId,
                                                   flowAllocateHandle_t *pxFlowRequest,
-                                                  struct ipcpNormalData_t *pxIpcpData)
+                                                  struct ipcpInstanceData_t *pxIpcpData)
 #else
 void vFlowAllocatorFlowRequest(struct efcpContainer_t *pxEfcpc,
                                portId_t xPortId,
                                flowAllocateHandle_t *pxFlowRequest,
-                               struct ipcpNormalData_t *pxIpcpData)
+                               struct ipcpInstanceData_t *pxIpcpData)
 #endif
 {
 }

--- a/components_mocks/mock_IPCP/ipcp.c
+++ b/components_mocks/mock_IPCP/ipcp.c
@@ -48,7 +48,7 @@ bool_t xSendEventStructToIPCPTask(const RINAStackEvent_t *pxEvent,
              pxEvent->eEventType == eNetworkTxEvent);
 
     sentEvent.eEventType = pxEvent->eEventType;
-    sentEvent.pvData = pxEvent->pvData;
+    sentEvent.xData.PV = pxEvent->xData.PV;
 
     LOGD(TAG_MOCK_IPCP, "Sending event: %d", pxEvent->eEventType);
 

--- a/components_mocks/mock_Ribd/include/Ribd_api.h
+++ b/components_mocks/mock_Ribd/include/Ribd_api.h
@@ -1,13 +1,14 @@
 #ifndef _mock_RIBD_RIBD_H
 #define _mock_RIBD_RIBD_H
 
+#include "common/rina_ids.h"
 #include "rmt.h"
 #include "IPCP_instance.h"
-#include "common/rina_ids.h"
+#include "IPCP_normal_defs.h"
 
-bool_t xRibdConnectToIpcp(struct ipcpNormalData_t *pxIpcpData, name_t *pxSource, name_t *pxDestInfo, portId_t xN1flowPortId, authPolicy_t *pxAuth);
+bool_t xRibdConnectToIpcp(struct ipcpInstanceData_t *pxIpcpData, name_t *pxSource, name_t *pxDestInfo, portId_t xN1flowPortId, authPolicy_t *pxAuth);
 bool_t xRibdDisconnectToIpcp(portId_t xN1flowPortId);
-bool_t xRibdProcessLayerManagementPDU(struct ipcpNormalData_t *pxData, portId_t xN1flowPortId, struct du_t *pxDu);
+bool_t xRibdProcessLayerManagementPDU(struct ipcpInstanceData_t *pxData, portId_t xN1flowPortId, struct du_t *pxDu);
 bool_t xRibdSendRequest(string_t pcObjClass, string_t pcObjName, long objInst,
                         opCode_t eOpCode, portId_t xN1flowPortId, serObjectValue_t *pxObjVal);
 bool_t xRibdSendResponse(string_t pcObjClass, string_t pcObjName, long objInst,

--- a/components_mocks/mock_Ribd/ribd.c
+++ b/components_mocks/mock_Ribd/ribd.c
@@ -8,4 +8,5 @@ bool_t xRibdProcessLayerManagementPDU(struct ipcpInstanceData_t *pxData,
                                       portId_t xN1flowPortId,
                                       struct du_t *pxDu)
 {
+    return true;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,16 @@ if(NOT $ENV{IDF_PATH} STREQUAL "")
   set(ENV{NETWORKINTERFACE_MODULE} "mq")
 
   include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+  add_compile_options(
+    -Wno-unused-but-set-variable
+    -Wno-unused-function
+    -Wno-unused-variable
+    -Wno-unused-parameter
+  )
+
   project(unit_test)
+
 else()
   message(FATAL "This CMakeLists.txt file is to use with the ESP IDF only!")
 endif()

--- a/test_linux/CMakeLists.txt
+++ b/test_linux/CMakeLists.txt
@@ -1,0 +1,22 @@
+if (${TARGET_TYPE} STREQUAL "linux")
+  set(NETWORK_INTERFACE_MODULE "linux_tap")
+
+  add_executable(test_linux
+    test_linux.c
+  )
+  target_link_libraries(test_linux PUBLIC
+    ShimIPCP
+    IPCP
+    NetworkInterface_TAP
+    configSensor
+    BufferManagement
+    ARP826
+    Rmt
+    EFCP
+    Enrollment
+    Ribd
+    FlowAllocator
+  )
+else()
+  message(FATAL_ERROR "This CMakeLists file is to use with the 'linux' target only.")
+endif()

--- a/test_linux/test_linux.c
+++ b/test_linux/test_linux.c
@@ -1,0 +1,6 @@
+#include "IPCP_api.h"
+
+int main() {
+    RINA_IPCPInit();
+    pause();
+}


### PR DESCRIPTION
This allows us to avoid awkwardly casting from a void pointer to the various types that the event might hold.