### PR TITLE
Don't pass pointers to stack buffer to callers!

### DIFF
--- a/components/FlowAllocator/FlowAllocator.c
+++ b/components/FlowAllocator/FlowAllocator.c
@@ -290,6 +290,9 @@ void vFlowAllocatorFlowRequest(
         LOGE(TAG_FA, "It was a problem to send the request");
         // return pdFALSE;
     }
+
+    if (pxObjVal != NULL)
+        vRsMemFree(pxObjVal);
 }
 
 bool_t xFlowAllocatorHandleCreateR(serObjectValue_t *pxSerObjValue, int result)


### PR DESCRIPTION
This allocates a block of memory to hold the content of the serialisation of the flow data instead of passing a pointer to a stack buffer.

The callers needs to free the buffer allocated itself.