### PR TITLE
Generate random ethernet address for remote side of Linux TAP

### DIFF
--- a/components/NetworkInterface/esp32/NetworkInterface.c
+++ b/components/NetworkInterface/esp32/NetworkInterface.c
@@ -107,7 +107,7 @@ static void event_handler(void *arg, esp_event_base_t event_base,
  *  Mac address variable in the ShimIPCP.h
  *  Return a Boolean pdTrue or pdFalse
  * */
-BaseType_t xNetworkInterfaceInitialise(const MACAddress_t *pxPhyDev)
+BaseType_t xNetworkInterfaceInitialise(MACAddress_t *pxPhyDev)
 {
 	ESP_LOGI(TAG_WIFI, "Initializing the network interface");
 	uint8_t ucMACAddress[MAC_ADDRESS_LENGTH_BYTES];

--- a/components/NetworkInterface/include/NetworkInterface.h
+++ b/components/NetworkInterface/include/NetworkInterface.h
@@ -12,7 +12,7 @@
     //#include "ShimIPCP.h"
 
     /* INTERNAL API FUNCTIONS. */
-    bool_t xNetworkInterfaceInitialise(const MACAddress_t *phyDev);
+    bool_t xNetworkInterfaceInitialise(MACAddress_t *phyDev);
     bool_t xNetworkInterfaceOutput(NetworkBufferDescriptor_t *const pxNetworkBuffer,
                                    bool_t xReleaseAfterSend);
 

--- a/components/NetworkInterface/mq/NetworkInterface.c
+++ b/components/NetworkInterface/mq/NetworkInterface.c
@@ -169,7 +169,7 @@ static void event_handler(union sigval sv)
 
 /* Public interface */
 
-bool_t xNetworkInterfaceInitialise(const MACAddress_t *pxPhyDev)
+bool_t xNetworkInterfaceInitialise(MACAddress_t *pxPhyDev)
 {
     /* Save the MAC address to use as queue names. */
     mac2str(pxPhyDev, sMac, sizeof(sMac));

--- a/components/ShimIPCP/ShimIPCP.c
+++ b/components/ShimIPCP/ShimIPCP.c
@@ -91,7 +91,7 @@ EthernetHeader_t *vCastConstPointerTo_EthernetHeader_t(const void *pvArgument)
  *
  * @return: pdTrue or pdFalse
  * */
-bool_t xShimEnrollToDIF(const MACAddress_t *pxPhyDev)
+bool_t xShimEnrollToDIF(MACAddress_t *pxPhyDev)
 {
 	LOGI(TAG_SHIM, "Enrolling to DIF");
 

--- a/components/ShimIPCP/include/ShimIPCP.h
+++ b/components/ShimIPCP/include/ShimIPCP.h
@@ -53,7 +53,7 @@ typedef struct xSHIM_WIFI_FLOW
 	RsListItem_t		xFlowItem;
 } shimFlow_t;
 
-bool_t xShimEnrollToDIF( const MACAddress_t * pxPhyDev );
+bool_t xShimEnrollToDIF( MACAddress_t * pxPhyDev );
 
 /*-------------------------------------------*/
 /* FlowAllocateRequest (naming-info). Naming-info about the destination.


### PR DESCRIPTION
There was a bit of confusion there on what to do. When creating a tap interface, Linux attributes it a random ethernet address. This address is actually NOT to be used to send packets as it confuses Linux: packets coming out of an interface should not have the same source address as the destination.

While this behaviour did not cause any problems in our tests, it was not correct. I fixed this by generating an random ethernet address to act as the remote side of the TAP.