### PR TITLE
Moving-eth.processing-to-shim

### DIFF
--- a/components/Common/include/common/mac.h
+++ b/components/Common/include/common/mac.h
@@ -7,23 +7,27 @@
 #include "portability/port.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #define MAC2STR_MIN_BUFSZ 18
 
-//Structure MAC ADDRESS
-typedef struct xMAC_ADDRESS
-{
-	uint8_t ucBytes[ MAC_ADDRESS_LENGTH_BYTES ]; /**< Byte array of the MAC address */
-} MACAddress_t;
+    // Structure MAC ADDRESS
+    typedef struct xMAC_ADDRESS
+    {
+        uint8_t ucBytes[MAC_ADDRESS_LENGTH_BYTES]; /**< Byte array of the MAC address */
+    } MACAddress_t;
 
-//enum MAC Address
-typedef enum {
-    MAC_ADDR_802_3
-} eGHAType_t;
+    // enum MAC Address
+    typedef enum
+    {
+        MAC_ADDR_802_3
+    } eGHAType_t;
 
-void mac2str(const MACAddress_t *, string_t, const size_t);
+    void mac2str(const MACAddress_t *, string_t, const size_t);
+
+    bool_t xIsBroadcastMac(const MACAddress_t *pxMac);
 
 #ifdef __cplusplus
 }

--- a/components/Common/mac.c
+++ b/components/Common/mac.c
@@ -4,7 +4,8 @@
 #include "portability/port.h"
 #include "common/mac.h"
 
-void mac2str(const MACAddress_t *pxMac, string_t psMac, const size_t p) {
+void mac2str(const MACAddress_t *pxMac, string_t psMac, const size_t p)
+{
     const uint8_t *m = pxMac->ucBytes;
 
     RsAssert(p >= MAC2STR_MIN_BUFSZ);
@@ -12,4 +13,10 @@ void mac2str(const MACAddress_t *pxMac, string_t psMac, const size_t p) {
              m[0], m[1], m[2], m[3], m[4], m[5]);
 }
 
+bool_t xIsBroadcastMac(const MACAddress_t *pxMac)
+{
+    const MACAddress_t xBroadcastMac = {
+        .ucBytes = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 
+    return memcmp(pxMac, &xBroadcastMac, MAC_ADDRESS_LENGTH_BYTES) == 0;
+}

--- a/components/IPCP/IPCP.c
+++ b/components/IPCP/IPCP.c
@@ -713,29 +713,6 @@ void prvProcessEthernetPacket(NetworkBufferDescriptor_t *const pxNetworkBuffer)
     }
 }
 
-eFrameProcessingResult_t eConsiderFrameForProcessing(const uint8_t *const pucEthernetBuffer)
-{
-    eFrameProcessingResult_t eReturn = eReleaseBuffer;
-    const EthernetHeader_t *pxEthernetHeader;
-    uint16_t usFrameType;
-
-    /* Map the buffer onto Ethernet Header struct for easy access to fields. */
-    pxEthernetHeader = (EthernetHeader_t *)pucEthernetBuffer;
-
-    usFrameType = RsNtoHS(pxEthernetHeader->usFrameType);
-
-    // Just ETH_P_ARP and ETH_P_RINA Should be processed by the stack
-    if (usFrameType == ETH_P_RINA_ARP || usFrameType == ETH_P_RINA)
-    {
-        eReturn = eProcessBuffer;
-        LOGD(TAG_IPCPMANAGER, "Ethernet packet of type %xu: ACCEPTED", usFrameType);
-    }
-    else
-        LOGD(TAG_IPCPMANAGER, "Ethernet packet of type %xu: REJECTED", usFrameType);
-
-    return eReturn;
-}
-
 /*-----------------------------------------------------------*/
 
 /**

--- a/components/IPCP/IpcManager.c
+++ b/components/IPCP/IpcManager.c
@@ -36,6 +36,30 @@ static InstanceTableRow_t xInstanceTable[INSTANCES_IPCP_ENTRIES];
  * @param pxIpcManager object created in the IPCP TASK.
  * @return BaseType_t
  */
+
+/**
+ * @brief Add an IPCP instance into the Ipcp Instance Table.
+ *
+ * @param pxIpcpInstaceToAdd to added into the table
+ */
+void prvIpcpMngrAddInstanceEntry(struct ipcpInstance_t *pxIpcpInstaceToAdd)
+{
+    num_t x = 0;
+
+    for (x = 0; x < INSTANCES_IPCP_ENTRIES; x++)
+    {
+        if (xInstanceTable[x].xActive == false)
+        {
+            xInstanceTable[x].pxIpcpInstance = pxIpcpInstaceToAdd;
+            xInstanceTable[x].pxIpcpType = pxIpcpInstaceToAdd->xType;
+            xInstanceTable[x].xIpcpId = pxIpcpInstaceToAdd->xId;
+            xInstanceTable[x].xActive = true;
+
+            break;
+        }
+    }
+}
+
 bool_t xIpcManagerInit(ipcManager_t *pxIpcManager)
 {
     if ((pxIpcManager->pxPidm = pxNumMgrCreate(MAX_PORT_ID)) == NULL)
@@ -102,13 +126,10 @@ struct ipcpInstance_t *pxIpcManagerFindInstanceByType(ipcpInstanceType_t xType)
 
     for (x = 0; x < INSTANCES_IPCP_ENTRIES; x++)
     {
-        LOGE(TAG_IPCPMANAGER, "finding: %i", x);
         if (xInstanceTable[x].xActive == true)
         {
-            LOGE(TAG_IPCPMANAGER, "active");
             if (xInstanceTable[x].pxIpcpType == xType)
             {
-                LOGE(TAG_IPCPMANAGER, "type: %i", xType);
                 return xInstanceTable[x].pxIpcpInstance;
                 break;
             }
@@ -165,10 +186,13 @@ struct ipcpInstance_t *pxIpcManagerCreateShim(ipcManager_t *pxIpcManager)
 {
 
     ipcProcessId_t xIpcpId;
+    struct ipcpInstance_t *pxInstance;
 
     xIpcpId = ulNumMgrAllocate(pxIpcManager->pxIpcpIdm);
 
     // add the shimInstance into the instance list.
 
-    return pxShimWiFiCreate(xIpcpId);
+    pxInstance = pxShimWiFiCreate(xIpcpId);
+    prvIpcpMngrAddInstanceEntry(pxInstance);
+    return pxInstance;
 }

--- a/components/IPCP/IpcManager.c
+++ b/components/IPCP/IpcManager.c
@@ -96,16 +96,19 @@ struct ipcpInstance_t *pxIpcManagerFindInstanceById(ipcpInstanceId_t xIpcpId)
  * @return ipcpInstance_t* pointer to the ipcp instance.
  */
 
-static struct ipcpInstance_t *pxIpcManagerFindInstanceByType(ipcpInstanceType_t xType)
+struct ipcpInstance_t *pxIpcManagerFindInstanceByType(ipcpInstanceType_t xType)
 {
     num_t x = 0;
 
     for (x = 0; x < INSTANCES_IPCP_ENTRIES; x++)
     {
+        LOGE(TAG_IPCPMANAGER, "finding: %i", x);
         if (xInstanceTable[x].xActive == true)
         {
+            LOGE(TAG_IPCPMANAGER, "active");
             if (xInstanceTable[x].pxIpcpType == xType)
             {
+                LOGE(TAG_IPCPMANAGER, "type: %i", xType);
                 return xInstanceTable[x].pxIpcpInstance;
                 break;
             }

--- a/components/IPCP/include/IPCP_api.h
+++ b/components/IPCP/include/IPCP_api.h
@@ -12,30 +12,29 @@
 #include "common/rina_ids.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/*
- * Send the event eEvent to the IPCP task event queue, using a block time of
- * zero.  Return pdPASS if the message was sent successfully, otherwise return
- * pdFALSE.
- */
-bool_t xSendEventToIPCPTask(eRINAEvent_t eEvent);
+    /*
+     * Send the event eEvent to the IPCP task event queue, using a block time of
+     * zero.  Return pdPASS if the message was sent successfully, otherwise return
+     * pdFALSE.
+     */
+    bool_t xSendEventToIPCPTask(eRINAEvent_t eEvent);
 
-/* Returns true is this function is called from the IPCP-task */
-bool_t xIsCallingFromIPCPTask(void);
+    /* Returns true is this function is called from the IPCP-task */
+    bool_t xIsCallingFromIPCPTask(void);
 
-bool_t xSendEventStructToIPCPTask(const RINAStackEvent_t *pxEvent,
-                                  useconds_t uxTimeoutUS);
+    bool_t xSendEventStructToIPCPTask(const RINAStackEvent_t *pxEvent,
+                                      useconds_t uxTimeoutUS);
 
-eFrameProcessingResult_t eConsiderFrameForProcessing(const uint8_t *const pucEthernetBuffer);
+    bool_t RINA_IPCPInit(void);
 
-bool_t RINA_IPCPInit(void);
+    struct rmt_t *pxIPCPGetRmt(void);
+    struct efcpContainer_t *pxIPCPGetEfcpc(void);
 
-struct rmt_t *pxIPCPGetRmt(void);
-struct efcpContainer_t *pxIPCPGetEfcpc(void);
-
-portId_t xIPCPAllocatePortId(void);
+    portId_t xIPCPAllocatePortId(void);
 
 #ifdef __cplusplus
 }

--- a/components/IPCP/include/IpcManager.h
+++ b/components/IPCP/include/IpcManager.h
@@ -8,56 +8,59 @@
 #include "RINA_API_flows.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct xINSTANCE_TABLE_ROW
-{
-	/*The Ipcp Instance to register*/
-	struct ipcpInstance_t *pxIpcpInstance;
+	typedef struct xINSTANCE_TABLE_ROW
+	{
+		/*The Ipcp Instance to register*/
+		struct ipcpInstance_t *pxIpcpInstance;
 
-	/*Type of the Ipcp Instance to register*/
-	ipcpInstanceType_t pxIpcpType;
+		/*Type of the Ipcp Instance to register*/
+		ipcpInstanceType_t pxIpcpType;
 
-	/*The Ipcp Id to registered*/
-	ipcProcessId_t xIpcpId;
+		/*The Ipcp Id to registered*/
+		ipcProcessId_t xIpcpId;
 
-	/*Is the Ipcp Instace active?*/
-	bool_t xActive;
+		/*Is the Ipcp Instace active?*/
+		bool_t xActive;
 
-} InstanceTableRow_t;
+	} InstanceTableRow_t;
 
-typedef struct xIPC_MANAGER
-{
-	/*List of the Ipcp factories registered*/
-	// factories_t *pxFactories;
+	typedef struct xIPC_MANAGER
+	{
+		/*List of the Ipcp factories registered*/
+		// factories_t *pxFactories;
 
-	RsList_t xShimInstancesList;
+		RsList_t xShimInstancesList;
 
-	// flowAllocator_t * pxFlowAllocator;
-	// InstanceTableRow_t * pxInstanceTable[ INSTANCES_IPCP_ENTRIES ];
+		// flowAllocator_t * pxFlowAllocator;
+		// InstanceTableRow_t * pxInstanceTable[ INSTANCES_IPCP_ENTRIES ];
 
-	/*port Id manager*/
-	NumMgr_t *pxPidm;
+		/*port Id manager*/
+		NumMgr_t *pxPidm;
 
-	/*IPCProcess Id manager*/
-	NumMgr_t *pxIpcpIdm;
+		/*IPCProcess Id manager*/
+		NumMgr_t *pxIpcpIdm;
 
-} ipcManager_t;
+	} ipcManager_t;
 
-bool_t xIpcManagerInit(ipcManager_t *pxIpcManager);
+	bool_t xIpcManagerInit(ipcManager_t *pxIpcManager);
 
-void vIcpManagerEnrollmentFlowRequest(struct ipcpInstance_t *pxShimInstance, portId_t xN1PortId, name_t *pxIPCPName);
+	void vIcpManagerEnrollmentFlowRequest(struct ipcpInstance_t *pxShimInstance, portId_t xN1PortId, name_t *pxIPCPName);
 
-void vIpcpManagerAppFlowAllocateRequestHandle(flowAllocateHandle_t *pxFlowAllocateRequest);
+	void vIpcpManagerAppFlowAllocateRequestHandle(flowAllocateHandle_t *pxFlowAllocateRequest);
 
-// BaseType_t xIpcManagerWriteMgmtHandler(ipcpFactoryType_t xType, void *pxData);
+	// BaseType_t xIpcManagerWriteMgmtHandler(ipcpFactoryType_t xType, void *pxData);
 
-struct ipcpInstance_t *pxIpcManagerFindInstanceById(ipcpInstanceId_t xIpcpId);
+	struct ipcpInstance_t *pxIpcManagerFindInstanceById(ipcpInstanceId_t xIpcpId);
 
-void vIpcManagerRINAPackettHandler(struct ipcpInstanceData_t *pxData, NetworkBufferDescriptor_t *pxNetworkBuffer);
+	void vIpcManagerRINAPackettHandler(struct ipcpInstanceData_t *pxData, NetworkBufferDescriptor_t *pxNetworkBuffer);
 
-struct ipcpInstance_t *pxIpcManagerCreateShim(ipcManager_t *pxIpcManager);
+	struct ipcpInstance_t *pxIpcManagerCreateShim(ipcManager_t *pxIpcManager);
+
+	struct ipcpInstance_t *pxIpcManagerFindInstanceByType(ipcpInstanceType_t xType);
 
 #ifdef __cplusplus
 }

--- a/components/Shim/Shim.c
+++ b/components/Shim/Shim.c
@@ -1022,3 +1022,167 @@ bool_t xShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance)
 		return true;
 	}
 }
+
+eFrameProcessingResult_t eConsiderFrameForProcessing(const uint8_t *const pucEthernetBuffer)
+{
+	eFrameProcessingResult_t eReturn = eReleaseBuffer;
+	const EthernetHeader_t *pxEthernetHeader;
+	uint16_t usFrameType;
+
+	/* Map the buffer onto Ethernet Header struct for easy access to fields. */
+	pxEthernetHeader = (EthernetHeader_t *)pucEthernetBuffer;
+
+	usFrameType = RsNtoHS(pxEthernetHeader->usFrameType);
+
+	// Just ETH_P_ARP and ETH_P_RINA Should be processed by the stack
+	if (usFrameType == ETH_P_RINA_ARP || usFrameType == ETH_P_RINA)
+	{
+		eReturn = eProcessBuffer;
+		LOGD(TAG_IPCPMANAGER, "Ethernet packet of type %xu: ACCEPTED", usFrameType);
+	}
+	else
+		LOGD(TAG_IPCPMANAGER, "Ethernet packet of type %xu: REJECTED", usFrameType);
+
+	return eReturn;
+}
+
+void vShimHandleEthernetPacket(NetworkBufferDescriptor_t *const pxNetworkBuffer)
+{
+	const EthernetHeader_t *pxEthernetHeader;
+	eFrameProcessingResult_t eReturned = eFrameConsumed;
+	uint16_t usFrameType;
+	struct ipcpInstance_t *pxSelf;
+
+	RsAssert(pxNetworkBuffer != NULL);
+
+	/*Call the IpcManager to retrieve the IPCP shim WiFi instance*/
+	pxSelf = pxIpcManagerFindInstanceByType(eShimWiFi);
+
+	if (pxSelf == NULL)
+	{
+		LOGE(TAG_SHIM, "Error no instance founded");
+	}
+
+	/* Interpret the Ethernet frame. */
+	if (pxNetworkBuffer->xEthernetDataLength >= sizeof(EthernetHeader_t))
+	{
+		/* Map the buffer onto the Ethernet Header struct for easy access to the fields. */
+		pxEthernetHeader = (EthernetHeader_t *)pxNetworkBuffer->pucEthernetBuffer;
+		usFrameType = RsNtoHS(pxEthernetHeader->usFrameType);
+
+		/* Interpret the received Ethernet packet. */
+		switch (usFrameType)
+		{
+		case ETH_P_RINA_ARP:
+
+			/* The Ethernet frame contains an ARP packet. */
+			LOGI(TAG_IPCPMANAGER, "ARP Packet Received");
+
+			if (pxNetworkBuffer->xEthernetDataLength >= sizeof(ARPPacket_t))
+			{
+				/*Process the Packet ARP in case of REPLY -> eProcessBuffer, REQUEST -> eReturnEthernet to
+				 * send to the destination a REPLY (It requires more processing tasks) */
+				eReturned = eARPProcessPacket(CAST_PTR_TO_TYPE_PTR(ARPPacket_t, pxNetworkBuffer->pucEthernetBuffer));
+			}
+			else
+			{
+				/*If ARP packet is not correct estructured then release buffer*/
+				eReturned = eReleaseBuffer;
+			}
+
+			break;
+
+		case ETH_P_RINA:
+
+			LOGI(TAG_IPCPMANAGER, "RINA Packet Received");
+
+			uint8_t *ptr;
+			size_t uxRinaLength;
+			// NetworkBufferDescriptor_t *pxBuffer;
+
+			// removing Ethernet Header
+			uxRinaLength = pxNetworkBuffer->xEthernetDataLength - (size_t)14;
+
+			// ESP_LOGE(TAG_ARP, "Taking Buffer to copy the RINA PDU: ETH_P_RINA");
+			// pxBuffer = pxGetNetworkBufferWithDescriptor(xlength, (TickType_t)0U);
+
+			// Copy into the newBuffer but just the RINA PDU, and not the Ethernet Header
+			ptr = (uint8_t *)pxNetworkBuffer->pucEthernetBuffer + 14;
+
+			pxNetworkBuffer->xRinaDataLength = uxRinaLength;
+			pxNetworkBuffer->pucRinaBuffer = ptr;
+
+			// Release the buffer with the Ethernet header, it is not needed any more
+			// ESP_LOGE(TAG_ARP, "Releasing Buffer to copy the RINA PDU: ETH_P_RINA");
+			// vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+
+			// must be void function
+			vIpcManagerRINAPackettHandler(pxSelf->pxData, pxNetworkBuffer); // must change
+
+			break;
+
+		default:
+			LOGE(TAG_WIFI, "No Case Ethernet Type, Drop Frame");
+			eReturned = eReleaseBuffer;
+
+			break;
+		}
+	}
+	//}
+
+	/* Perform any actions that resulted from processing the Ethernet frame. */
+	switch (eReturned)
+	{
+	case eReturnEthernetFrame:
+
+		/* The Ethernet frame will have been updated (maybe it was
+		 * an ARP request) and should be sent back to
+		 * its source. */
+		// vReturnEthernetFrame( pxNetworkBuffer, pdTRUE );
+
+		/* parameter pdTRUE: the buffer must be released once
+		 * the frame has been transmitted */
+		break;
+
+	case eFrameConsumed:
+
+		/* The frame is in use somewhere, don't release the buffer
+		 * yet. */
+		LOGI(TAG_SHIM, "Frame Consumed");
+		break;
+
+	case eReleaseBuffer:
+		// ESP_LOGI(TAG_SHIM, "Releasing Buffer: ProcessEthernet");
+		if (pxNetworkBuffer != NULL)
+		{
+			vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+		}
+
+		break;
+	case eProcessBuffer:
+		/*ARP process buffer, call to ShimAllocateResponse*/
+
+		/* Finding an instance of eShimiFi and call the floww allocate Response using this instance*/
+
+		if (!pxSelf->pxOps->flowAllocateResponse(pxSelf->pxData, 1))
+		{
+			LOGE(TAG_IPCPMANAGER, "Error during the Allocation Request at Shim");
+			vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+		}
+		else
+		{
+			LOGI(TAG_IPCPMANAGER, "Buffer Processed");
+			vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+		}
+
+		break;
+	default:
+
+		/* The frame is not being used anywhere, and the
+		 * NetworkBufferDescriptor_t structure containing the frame should
+		 * just be released back to the list of free buffers. */
+		// ESP_LOGI(TAG_SHIM, "Default: Releasing Buffer");
+		vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+		break;
+	}
+}

--- a/components/Shim/Shim.c
+++ b/components/Shim/Shim.c
@@ -1117,7 +1117,7 @@ void vShimHandleEthernetPacket(NetworkBufferDescriptor_t *const pxNetworkBuffer)
 			// vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
 
 			// must be void function
-			vIpcManagerRINAPackettHandler(pxSelf->pxData, pxNetworkBuffer); // must change
+			vIpcManagerRINAPackettHandler(pxSelf->pxData, pxNetworkBuffer); // must change this must be managed by the shim instead to call IPCPManager
 
 			break;
 

--- a/components/Shim/include/Shim.h
+++ b/components/Shim/include/Shim.h
@@ -19,116 +19,118 @@
 #include "rina_common_port.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* Flow states */
-typedef enum xFLOW_STATES
+	/* Flow states */
+	typedef enum xFLOW_STATES
 
-{
-	eNULL = 0,	// The Port_id cannot be used
-	ePENDING,	// The protocol has either initiated the flow allocation or waiting for allocateResponse.
-	eALLOCATED, // Flow allocated and the port_id can be used to read/write data from/to.
-} ePortidState_t;
+	{
+		eNULL = 0,	// The Port_id cannot be used
+		ePENDING,	// The protocol has either initiated the flow allocation or waiting for allocateResponse.
+		eALLOCATED, // Flow allocated and the port_id can be used to read/write data from/to.
+	} ePortidState_t;
 
-/* Holds the information related to one flow */
+	/* Holds the information related to one flow */
 
-typedef struct xSHIM_WIFI_FLOW
-{
-	/* Harward Destination Address (MAC)*/
-	gha_t *pxDestHa;
+	typedef struct xSHIM_WIFI_FLOW
+	{
+		/* Harward Destination Address (MAC)*/
+		gha_t *pxDestHa;
 
-	/* Protocol Destination Address (Address RINA)*/
-	gpa_t *pxDestPa;
+		/* Protocol Destination Address (Address RINA)*/
+		gpa_t *pxDestPa;
 
-	/* Port Id of???*/
-	portId_t xPortId;
+		/* Port Id of???*/
+		portId_t xPortId;
 
-	/* State of the PortId */
-	ePortidState_t ePortIdState;
+		/* State of the PortId */
+		ePortidState_t ePortIdState;
 
-	/* IPCP Instance who is going to use the Flow*/
-	struct ipcpInstance * pxUserIpcp;
+		/* IPCP Instance who is going to use the Flow*/
+		struct ipcpInstance *pxUserIpcp;
 
-	/* Maybe this is not needed*/
-	rfifo_t *pxSduQueue;
+		/* Maybe this is not needed*/
+		rfifo_t *pxSduQueue;
 
-	/* Flow item to register in the List of Shim WiFi Flows */
-	RsListItem_t		xFlowItem;
-} shimFlow_t;
+		/* Flow item to register in the List of Shim WiFi Flows */
+		RsListItem_t xFlowItem;
+	} shimFlow_t;
 
-bool_t xShimEnrollToDIF( MACAddress_t * pxPhyDev );
+	bool_t xShimEnrollToDIF(MACAddress_t *pxPhyDev);
 
-/*-------------------------------------------*/
-/* FlowAllocateRequest (naming-info). Naming-info about the destination.
- * Primitive invoked by a source application to request a new flow:
- * - Check if there is a flow estabished (eALLOCATED), or a flow pending between the
- * source and destination application (ePENDING),
- * - If stated is eNULL then RINA_xARPMapping is called.
- * */
-bool_t xShimFlowAllocateRequest(struct ipcpInstanceData_t *pxData,
-                                name_t *pxSourceInfo,
-                                name_t *pxDestinationInfo,
-                                portId_t xPortId);
+	/*-------------------------------------------*/
+	/* FlowAllocateRequest (naming-info). Naming-info about the destination.
+	 * Primitive invoked by a source application to request a new flow:
+	 * - Check if there is a flow estabished (eALLOCATED), or a flow pending between the
+	 * source and destination application (ePENDING),
+	 * - If stated is eNULL then RINA_xARPMapping is called.
+	 * */
+	bool_t xShimFlowAllocateRequest(struct ipcpInstanceData_t *pxData,
+									name_t *pxSourceInfo,
+									name_t *pxDestinationInfo,
+									portId_t xPortId);
 
+	bool_t xShimFlowAllocateResponse(struct ipcpInstanceData_t *pxShimInstanceData, portId_t xPortId);
 
-bool_t xShimFlowAllocateResponse(struct ipcpInstanceData_t *pxShimInstanceData, portId_t xPortId);
+	/*-------------------------------------------*/
+	/* FlowDeallocate.
+	 * Primitive invoked by the application to discard all state regarding this flow.
+	 * - Port_id change to eNULL.
+	 * */
+	bool_t xShimFlowDeallocate(struct ipcpInstanceData_t *pxData, portId_t xId);
 
-/*-------------------------------------------*/
-/* FlowDeallocate.
- * Primitive invoked by the application to discard all state regarding this flow.
- * - Port_id change to eNULL.
- * */
-bool_t xShimFlowDeallocate(struct ipcpInstanceData_t * pxData, portId_t xId);
+	/*-------------------------------------------*/
+	/* applicationRegister (naming-info)
+	 * Primitive invoked before all other functions:
+	 * - Transform the naming-info structure into a single string (application-name)
+	 * separated by "/": ProcessName/ProcessInstance/EntityName/EntityInstance
+	 * - Call the RINA_ARPAdd API to map the application Name to the Hardware Address
+	 * in the cache ARP. (Update LocalAddressProtocol and LocalAddressMAC)
+	 * Return a pdTrue if Success or pdFalse Failure.
+	 * */
 
-/*-------------------------------------------*/
-/* applicationRegister (naming-info)
- * Primitive invoked before all other functions:
- * - Transform the naming-info structure into a single string (application-name)
- * separated by "/": ProcessName/ProcessInstance/EntityName/EntityInstance
- * - Call the RINA_ARPAdd API to map the application Name to the Hardware Address
- * in the cache ARP. (Update LocalAddressProtocol and LocalAddressMAC)
- * Return a pdTrue if Success or pdFalse Failure.
- * */
+	bool_t xShimApplicationRegister(struct ipcpInstanceData_t *pxData,
+									name_t *pxAppName,
+									name_t *pxDafName);
 
-bool_t xShimApplicationRegister(struct ipcpInstanceData_t *pxData,
-                                name_t * pxAppName,
-								name_t * pxDafName);
+	/*-------------------------------------------*/
+	/* applicationUnregister (naming-info)
+	 * Primitive invoked before all other functions:
+	 * - Transform the naming-info into a single string (application-name)
+	 * separated by "/": ProcessName/ProcessInstance/EntityName/EntityInstance
+	 * - Call the RINA_ARPRemove API to remove the ARP
+	 * in the cache ARP.
+	 * Return a pdTrue if Success or pdFalse Failure.
+	 * */
+	bool_t xShimApplicationUnregister(struct ipcpInstanceData_t *pxData, const name_t *pxName);
 
-/*-------------------------------------------*/
-/* applicationUnregister (naming-info)
- * Primitive invoked before all other functions:
- * - Transform the naming-info into a single string (application-name)
- * separated by "/": ProcessName/ProcessInstance/EntityName/EntityInstance
- * - Call the RINA_ARPRemove API to remove the ARP
- * in the cache ARP.
- * Return a pdTrue if Success or pdFalse Failure.
- * */
-bool_t xShimApplicationUnregister(struct ipcpInstanceData_t *pxData, const name_t * pxName);
+	/*-------------------------------------------*/
+	/* Write (SDUs)
+	 * Primitive invoked by application to send SDUs.
+	 * - Create an Ethernet frame (802.11) using the Network Buffer Descriptor.
+	 * - Then put the Ethernet frame into the NetworkBufferDescriptor related to
+	 * Wifi layer.
+	 * */
+	void vShimWrite(void);
 
-/*-------------------------------------------*/
-/* Write (SDUs)
- * Primitive invoked by application to send SDUs.
- * - Create an Ethernet frame (802.11) using the Network Buffer Descriptor.
- * - Then put the Ethernet frame into the NetworkBufferDescriptor related to
- * Wifi layer.
- * */
-void vShimWrite(void);
+	/*-------------------------------------------*/
+	/* Read (SDUs)
+	 * Primitive invoked by application to read SDUs.
+	 *
+	 * */
+	void vShimRead(void);
 
-/*-------------------------------------------*/
-/* Read (SDUs)
- * Primitive invoked by application to read SDUs.
- *
- * */
-void vShimRead(void);
+	bool_t xShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance);
 
-bool_t xShimWiFiInit(struct ipcpInstance_t *pxShimWiFiInstance);
+	struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId);
 
-struct ipcpInstance_t *pxShimWiFiCreate(ipcProcessId_t xIpcpId);
+	bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_t *pxDu, bool_t uxBlocking);
 
-bool_t xShimSDUWrite(struct ipcpInstanceData_t *pxData, portId_t xId, struct du_t *pxDu, bool_t uxBlocking);
-
-EthernetHeader_t *vCastConstPointerTo_EthernetHeader_t(const void *pvArgument);
+	EthernetHeader_t *vCastConstPointerTo_EthernetHeader_t(const void *pvArgument);
+	eFrameProcessingResult_t eConsiderFrameForProcessing(const uint8_t *const pucEthernetBuffer);
+	void vShimHandleEthernetPacket(NetworkBufferDescriptor_t *const pxNetworkBuffer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I have moved the eth processing from the IPCP.c task into the Shim. It makes more sense that the Shim evaluate the ethernet packet and decides how to process this packet.  By the moment, the vShimHandleEthernetPacket is looking for the instance pointer in the IPCP manager table, but this seems impractical because for each packet arrived it must repeat this action. This must be improved.